### PR TITLE
Adjust RootHeader glass control sizing logic

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -495,11 +495,10 @@ struct RootHeaderGlassControl<Content: View>: View {
 
     var body: some View {
         let dimension = RootHeaderActionMetrics.dimension(for: capabilities)
-        let resolvedWidth = width ?? dimension
         let theme = themeManager.selectedTheme
 
         let control = content
-            .frame(width: resolvedWidth, height: dimension)
+            .modifier(RootHeaderGlassControlFrameModifier(width: width, dimension: dimension))
             .contentShape(Rectangle())
             .padding(.horizontal, RootHeaderGlassMetrics.horizontalPadding)
             .padding(.vertical, RootHeaderGlassMetrics.verticalPadding)
@@ -507,6 +506,27 @@ struct RootHeaderGlassControl<Content: View>: View {
 
         control
             .rootHeaderGlassDecorated(theme: theme, capabilities: capabilities)
+    }
+}
+
+private struct RootHeaderGlassControlFrameModifier: ViewModifier {
+    let width: CGFloat?
+    let dimension: CGFloat
+
+    func body(content: Content) -> some View {
+        if let width {
+            content
+                .frame(width: width, height: dimension)
+        } else {
+            content
+                .frame(
+                    minWidth: dimension,
+                    idealWidth: dimension,
+                    maxWidth: .infinity,
+                    minHeight: dimension,
+                    maxHeight: dimension
+                )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- allow RootHeaderGlassControl to expand horizontally when no explicit width is supplied
- preserve fixed sizing for controls that specify a width while sharing the same framing logic

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7e17d5070832cab18568c82254751