### PR TITLE
Improve macOS tab bar spacing and glass style

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -168,6 +168,17 @@ private struct MacRootTabBar: View {
         TranslucentButtonStyle.Metrics.macRootTab(for: platformCapabilities)
     }
 
+    private var minimumTabWidth: CGFloat {
+        let height = metrics.height ?? 44
+        let horizontalPadding = metrics.horizontalPadding
+
+        let glyphAllowance = height * 0.85
+        let labelAllowance = height * 1.4
+        let paddedWidth = glyphAllowance + labelAllowance + (horizontalPadding * 2)
+
+        return max(paddedWidth, height * 2.6)
+    }
+
     var body: some View {
         Group {
             if platformCapabilities.supportsOS26Translucency {
@@ -204,7 +215,7 @@ private struct MacRootTabBar: View {
     }
 
     private var glassSpacing: CGFloat {
-        max(metrics.horizontalPadding / 2, 8)
+        max(metrics.horizontalPadding * 0.75, 10)
     }
 
     private func legacyTabButton(for tab: RootTabView.Tab) -> some View {
@@ -219,7 +230,7 @@ private struct MacRootTabBar: View {
                 metrics: metrics
             )
         )
-        .frame(maxWidth: .infinity)
+        .frame(minWidth: minimumTabWidth, maxWidth: .infinity)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))
     }
@@ -233,12 +244,14 @@ private struct MacRootTabBar: View {
         } label: {
             MacTabLabel(tab: tab, isSelected: isSelected, palette: palette)
                 .padding(.horizontal, metrics.horizontalPadding)
-                .frame(maxWidth: .infinity)
+                .frame(minWidth: minimumTabWidth, maxWidth: .infinity)
                 .frame(height: metrics.height)
         }
-        .buttonStyle(.plain)
+        .controlSize(.large)
+        .buttonStyle(GlassButtonStyle())
+        .tint(palette.active)
         .contentShape(Capsule())
-        .frame(maxWidth: .infinity)
+        .frame(minWidth: minimumTabWidth, maxWidth: .infinity)
         .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
@@ -265,6 +278,8 @@ private struct MacTabLabel: View {
                 .font(.system(size: 13, weight: .semibold, design: .rounded))
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
+                .layoutPriority(1)
+                .allowsTightening(true)
                 .foregroundStyle(textForegroundColor)
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- add a shared minimum width metric for macOS root tab buttons to prevent truncation and keep capsules uniform
- update macOS 26 glass tab buttons to adopt the native GlassButtonStyle with palette tinting and large control sizing
- improve tab label layout priority and spacing so long titles stay legible while preserving the glass spacing guidance

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d7e63b75e4832cbe431770e08b99e7