### PR TITLE
Adjust glass button styling for macOS 26 tab bar

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -236,7 +236,9 @@ private struct MacRootTabBar: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: metrics.height)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.glass)
+        .buttonBorderShape(.capsule)
+        .tint(isSelected ? palette.active : palette.inactive)
         .contentShape(Capsule())
         .frame(maxWidth: .infinity)
         .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())


### PR DESCRIPTION
## Summary
- update the macOS 26 glass tab button to adopt the glass button style while preserving capsule shape and tinting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f377b268832c9cef0afd508d6d4e