### PR TITLE
Adopt system glass button style for macOS tab bar

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -236,10 +236,9 @@ private struct MacRootTabBar: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: metrics.height)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.glass)
         .contentShape(Capsule())
         .frame(maxWidth: .infinity)
-        .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))


### PR DESCRIPTION
## Summary
- update the macOS 26+ tab button styling to use the system `GlassButtonStyle`
- rely on the system-provided Liquid Glass background while keeping the union effect for transitions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f67366e0832cab3d19137a49f225