### PR TITLE
Inject platform capabilities into Mac root tab bar

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -116,7 +116,8 @@ struct RootTabView: View {
         ToolbarItem(placement: .principal) {
             MacRootTabBar(
                 selectedTab: $selectedTab,
-                palette: themeManager.selectedTheme.tabBarPalette
+                palette: themeManager.selectedTheme.tabBarPalette,
+                platformCapabilities: platformCapabilities
             )
             .frame(maxWidth: .infinity)
         }
@@ -147,21 +148,22 @@ private struct MacToolbarBackgroundModifier: ViewModifier {
 
 #if os(macOS)
 private struct MacRootTabBar: View {
-    @Environment(\.platformCapabilities) private var platformCapabilities
-
     private let tabs: [RootTabView.Tab]
     @Binding private var selectedTab: RootTabView.Tab
     private let palette: AppTheme.TabBarPalette
+    private let platformCapabilities: PlatformCapabilities
     @Namespace private var glassNamespace
 
     init(
         tabs: [RootTabView.Tab] = RootTabView.Tab.allCases,
         selectedTab: Binding<RootTabView.Tab>,
-        palette: AppTheme.TabBarPalette
+        palette: AppTheme.TabBarPalette,
+        platformCapabilities: PlatformCapabilities = .fallback
     ) {
         self.tabs = tabs
         self._selectedTab = selectedTab
         self.palette = palette
+        self.platformCapabilities = platformCapabilities
     }
 
     private var metrics: TranslucentButtonStyle.Metrics {


### PR DESCRIPTION
## Summary
- pass the resolved platform capabilities from `RootTabView` into the macOS root tab bar
- update `MacRootTabBar` to use the injected capabilities so Liquid Glass rendering engages on macOS 26

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fed36868832c8860d42424f8ce1d