### PR TITLE
Adjust macOS tab bar glass tint for neutral themes

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -84,6 +84,7 @@ enum CloudSyncPreferences {
 enum AppTheme: String, CaseIterable, Identifiable, Codable {
     struct TabBarPalette {
         let active: Color
+        let glassTint: Color
         let inactive: Color
         let disabled: Color
         let badgeBackground: Color
@@ -556,6 +557,22 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         let inactive = baseColor.opacity(inactiveAlpha)
         let disabled = baseColor.opacity(disabledAlpha)
 
+        let glassTint: Color
+        if let tintComponents = AppThemeColorUtilities.hsba(from: resolvedTint) {
+            let neutralFactor = max(0, 0.22 - tintComponents.saturation) / 0.22
+            let darknessFactor = max(0, 0.40 - tintComponents.brightness) / 0.40
+            let blendInfluence = max(neutralFactor, darknessFactor)
+
+            if blendInfluence > 0 {
+                let mixAmount = (0.28 + (blendInfluence * 0.32)).clamped(to: 0...0.6)
+                glassTint = AppThemeColorUtilities.mix(resolvedTint, Color.white, amount: mixAmount)
+            } else {
+                glassTint = resolvedTint
+            }
+        } else {
+            glassTint = resolvedTint
+        }
+
         let badgeBackground = resolvedTint
         let badgeBrightness = AppThemeColorUtilities.hsba(from: resolvedTint)?.brightness ?? 0.85
         let badgeForeground: Color
@@ -567,6 +584,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
 
         return TabBarPalette(
             active: active,
+            glassTint: glassTint,
             inactive: inactive,
             disabled: disabled,
             badgeBackground: badgeBackground,
@@ -575,6 +593,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         #else
         return TabBarPalette(
             active: resolvedTint,
+            glassTint: resolvedTint,
             inactive: Color.primary.opacity(0.75),
             disabled: Color.primary.opacity(0.34),
             badgeBackground: resolvedTint,

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -269,7 +269,7 @@ private struct MacRootTabBar: View {
         .buttonStyle(.plain)
         .contentShape(Capsule())
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)
-        .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())
+        .glassEffect(.regular.tint(palette.glassTint).interactive(), in: Capsule())
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))


### PR DESCRIPTION
## Summary
- expose a dedicated glass tint on the tab bar palette so liquid glass can stay bright
- derive the glass tint from the resolved theme tint, lightening near-neutral or dark colors
- update the macOS root tab bar to rely on the glass tint for its glass material buttons

## Testing
- not run (requires macOS build environment)


------
https://chatgpt.com/codex/tasks/task_e_68d807cbe22c832c93c1219d88e9b703