### PR TITLE
Use themed glass palette for macOS tab bar

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -120,6 +120,7 @@ struct RootTabView: View {
             MacRootTabBar(
                 selectedTab: $selectedTab,
                 palette: themeManager.selectedTheme.tabBarPalette,
+                glassPalette: themeManager.selectedTheme.glassPalette,
                 platformCapabilities: platformCapabilities
             )
             .frame(maxWidth: .infinity)
@@ -154,6 +155,7 @@ private struct MacRootTabBar: View {
     private let tabs: [RootTabView.Tab]
     @Binding private var selectedTab: RootTabView.Tab
     private let palette: AppTheme.TabBarPalette
+    private let glassPalette: AppTheme.GlassConfiguration.Palette
     private let platformCapabilities: PlatformCapabilities
     @Namespace private var glassNamespace
 
@@ -161,11 +163,13 @@ private struct MacRootTabBar: View {
         tabs: [RootTabView.Tab] = RootTabView.Tab.allCases,
         selectedTab: Binding<RootTabView.Tab>,
         palette: AppTheme.TabBarPalette,
+        glassPalette: AppTheme.GlassConfiguration.Palette,
         platformCapabilities: PlatformCapabilities = .fallback
     ) {
         self.tabs = tabs
         self._selectedTab = selectedTab
         self.palette = palette
+        self.glassPalette = glassPalette
         self.platformCapabilities = platformCapabilities
     }
 
@@ -269,7 +273,12 @@ private struct MacRootTabBar: View {
         .buttonStyle(.plain)
         .contentShape(Capsule())
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)
-        .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())
+        .glassEffect(
+            .regular
+                .tint(glassPalette.accent)
+                .interactive(),
+            in: Capsule()
+        )
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))


### PR DESCRIPTION
## Summary
- allow `MacRootTabBar` to accept a dedicated Liquid Glass palette when rendering tabs
- pass the selected theme's glass palette so glass tinting matches the tuned theme values
- update the macOS glass tab buttons to use the glass palette accent while keeping existing icon/text colors

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80980e900832c950469c9a5b35b22