### PR TITLE
Brighten macOS tab bar glass tint

### DIFF
--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -84,6 +84,7 @@ enum CloudSyncPreferences {
 enum AppTheme: String, CaseIterable, Identifiable, Codable {
     struct TabBarPalette {
         let active: Color
+        let glassTint: Color
         let inactive: Color
         let disabled: Color
         let badgeBackground: Color
@@ -556,6 +557,29 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         let inactive = baseColor.opacity(inactiveAlpha)
         let disabled = baseColor.opacity(disabledAlpha)
 
+        let glassTint: Color
+        if let tintComponents = AppThemeColorUtilities.hsba(from: resolvedTint) {
+            let isLowSaturation = tintComponents.saturation < 0.2
+            let isLowBrightness = tintComponents.brightness < 0.4
+
+            if isLowSaturation || isLowBrightness {
+                let blendAmount: Double
+                if tintComponents.brightness < 0.25 {
+                    blendAmount = 0.6
+                } else if tintComponents.brightness < 0.35 {
+                    blendAmount = 0.5
+                } else {
+                    blendAmount = 0.35
+                }
+
+                glassTint = AppThemeColorUtilities.mix(resolvedTint, Color.white, amount: blendAmount)
+            } else {
+                glassTint = resolvedTint
+            }
+        } else {
+            glassTint = resolvedTint
+        }
+
         let badgeBackground = resolvedTint
         let badgeBrightness = AppThemeColorUtilities.hsba(from: resolvedTint)?.brightness ?? 0.85
         let badgeForeground: Color
@@ -567,6 +591,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
 
         return TabBarPalette(
             active: active,
+            glassTint: glassTint,
             inactive: inactive,
             disabled: disabled,
             badgeBackground: badgeBackground,
@@ -575,6 +600,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         #else
         return TabBarPalette(
             active: resolvedTint,
+            glassTint: resolvedTint,
             inactive: Color.primary.opacity(0.75),
             disabled: Color.primary.opacity(0.34),
             badgeBackground: resolvedTint,

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -269,7 +269,7 @@ private struct MacRootTabBar: View {
         .buttonStyle(.plain)
         .contentShape(Capsule())
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)
-        .glassEffect(.regular.tint(palette.active).interactive(), in: Capsule())
+        .glassEffect(.regular.tint(palette.glassTint).interactive(), in: Capsule())
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))


### PR DESCRIPTION
## Summary
- add a glassTint value to the tab bar palette so translucent themes can specify a brighter liquid glass tint
- derive the glass tint by detecting dark or low-saturation accents and blending them with white for better visibility
- apply the new glass tint when rendering macOS glass tab buttons so they remain legible in inactive windows

## Testing
- not run (macOS build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80a6766d4832c8de802fede46100a