### PR TITLE
Adjust macOS header icon sizing

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -33,6 +33,11 @@ enum RootHeaderGlassMetrics {
     static let verticalPadding: CGFloat = DS.Spacing.xs * 0.75
 }
 
+enum RootHeaderControlSizing {
+    case automatic
+    case icon
+}
+
 // MARK: - Icon Content
 struct RootHeaderControlIcon: View {
     @EnvironmentObject private var themeManager: ThemeManager
@@ -487,25 +492,37 @@ struct RootHeaderGlassControl<Content: View>: View {
 
     private let content: Content
     private let width: CGFloat?
+    private let sizing: RootHeaderControlSizing
 
-    init(width: CGFloat? = nil, @ViewBuilder content: () -> Content) {
+    init(
+        width: CGFloat? = nil,
+        sizing: RootHeaderControlSizing = .automatic,
+        @ViewBuilder content: () -> Content
+    ) {
         self.content = content()
         self.width = width
+        self.sizing = sizing
     }
 
+    @ViewBuilder
     var body: some View {
         let dimension = RootHeaderActionMetrics.dimension(for: capabilities)
         let theme = themeManager.selectedTheme
 
-        let control = content
-            .modifier(RootHeaderGlassControlFrameModifier(width: width, dimension: dimension))
-            .contentShape(Rectangle())
-            .padding(.horizontal, RootHeaderGlassMetrics.horizontalPadding)
-            .padding(.vertical, RootHeaderGlassMetrics.verticalPadding)
-            .contentShape(Capsule(style: .continuous))
-
-        control
-            .rootHeaderGlassDecorated(theme: theme, capabilities: capabilities)
+        if sizing == .icon {
+            content
+                .frame(width: width ?? dimension, height: dimension)
+                .contentShape(Circle())
+                .rootHeaderGlassDecorated(theme: theme, capabilities: capabilities)
+        } else {
+            content
+                .modifier(RootHeaderGlassControlFrameModifier(width: width, dimension: dimension))
+                .contentShape(Rectangle())
+                .padding(.horizontal, RootHeaderGlassMetrics.horizontalPadding)
+                .padding(.vertical, RootHeaderGlassMetrics.verticalPadding)
+                .contentShape(Capsule(style: .continuous))
+                .rootHeaderGlassDecorated(theme: theme, capabilities: capabilities)
+        }
     }
 }
 
@@ -627,7 +644,12 @@ struct RootHeaderIconActionButton: View {
         // Always use RootHeaderGlassControl to keep consistent sizing and
         // alignment with the title row. Decoration is suppressed on
         // classic OS by RootHeaderGlassControl/rootHeaderGlassDecorated.
-        RootHeaderGlassControl {
+        let dimension = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(
+            width: dimension,
+            sizing: .icon
+        ) {
             baseButton
                 .buttonStyle(RootHeaderActionButtonStyle())
         }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -231,10 +231,6 @@ struct HomeView: View {
                     }
                 }
             }
-            .homeHeaderMatchedControlWidth(
-                intrinsicWidth: $headerActionPillIntrinsicWidth,
-                matchedWidth: matchedControlWidth
-            )
 
             if showsContextSummary || showsPeriodNavigation {
                 if showsContextSummary, let summary = headerSummary {
@@ -434,7 +430,9 @@ struct HomeView: View {
 
     // MARK: New: Standalone glass buttons for empty state header
     private func calendarMenuButton() -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Menu {
                 ForEach(BudgetPeriod.selectableCases) { period in
                     Button(period.displayName) { budgetPeriodRawValue = period.rawValue }
@@ -451,7 +449,9 @@ struct HomeView: View {
     }
 
     private func addBudgetIconButton() -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Button {
                 isPresentingAddBudget = true
             } label: {
@@ -463,7 +463,9 @@ struct HomeView: View {
     }
 
     private func optionsMenuButton() -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Menu {
                 Button {
                     isPresentingAddBudget = true
@@ -483,7 +485,9 @@ struct HomeView: View {
 
     // Add Expense button when no budget is active — presents direct add flows.
     private func addExpenseNoBudgetIconButton() -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Menu {
                 Button("Add Planned Expense") { isPresentingAddPlannedFromHome = true }
                 Button("Add Variable Expense") { isPresentingAddVariableFromHome = true }
@@ -499,7 +503,9 @@ struct HomeView: View {
     }
 
     private func addExpenseIconButton(for budgetID: NSManagedObjectID) -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Group {
             #if os(iOS)
                 Button { presentAddExpenseMenu(for: budgetID) } label: {
@@ -526,7 +532,9 @@ struct HomeView: View {
     }
 
     private func optionsMenuButton(summary: BudgetSummary) -> some View {
-        RootHeaderGlassControl {
+        let d = RootHeaderActionMetrics.dimension(for: capabilities)
+
+        return RootHeaderGlassControl(width: d, sizing: .icon) {
             Menu {
                 Button { isPresentingManageCards = true } label: { Label("Manage Cards", systemImage: "creditcard") }
                 Button { isPresentingManagePresets = true } label: { Label("Manage Presets", systemImage: "list.bullet.rectangle") }


### PR DESCRIPTION
## Summary
- add an icon sizing mode for `RootHeaderGlassControl` so icon-only controls stay square without stretching
- update shared icon button helpers and Home header menu buttons to request the new icon sizing on macOS
- keep Liquid Glass decorations gated behind the existing OS 26 capability while preserving the legacy flat styling for older systems

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d810996f10832c9df9db9f7e4f53ec