### PR TITLE
Simplify macOS glass tab styling

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -224,11 +224,9 @@ private struct MacRootTabBar: View {
 
     @available(macOS 26.0, *)
     private var glassTabBar: some View {
-        GlassEffectContainer(spacing: glassSpacing) {
-            HStack(spacing: glassSpacing) {
-                ForEach(tabs, id: \.self) { tab in
-                    glassTabButton(for: tab)
-                }
+        HStack(spacing: glassSpacing) {
+            ForEach(tabs, id: \.self) { tab in
+                glassTabButton(for: tab)
             }
         }
     }
@@ -265,11 +263,10 @@ private struct MacRootTabBar: View {
                 .padding(.horizontal, metrics.horizontalPadding)
                 .frame(minWidth: buttonContentMinWidth, maxWidth: .infinity)
                 .frame(height: metrics.height)
+                .glassEffect()
         }
         .buttonStyle(.plain)
-        .contentShape(Capsule())
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)
-        .glassEffect(.regular.interactive(), in: Capsule())
         .glassEffectUnion(id: tab, namespace: glassNamespace)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(accessibilityTraits(for: tab))


### PR DESCRIPTION
## Summary
- remove the capsule-specific glass container from the macOS tab bar
- apply the default glass effect to the tab button content to avoid custom tinting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d833130638832cb59c69cdaa52dda2