### PR TITLE
Use primary tint for root header icons

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -40,7 +40,6 @@ enum RootHeaderControlSizing {
 
 // MARK: - Icon Content
 struct RootHeaderControlIcon: View {
-    @EnvironmentObject private var themeManager: ThemeManager
     var systemImage: String
     /// Optional symbol variant override keeps headers in sync with design
     /// specifications when SF Symbols offer multiple contextual variants.
@@ -50,7 +49,7 @@ struct RootHeaderControlIcon: View {
         configuredImage
             .font(.system(size: 18, weight: .semibold))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .foregroundStyle(foregroundColor)
+            .foregroundStyle(.primary)
     }
 
     @ViewBuilder
@@ -63,9 +62,6 @@ struct RootHeaderControlIcon: View {
         }
     }
 
-    private var foregroundColor: Color {
-        themeManager.selectedTheme == .system ? Color.primary : Color.white
-    }
 }
 
 // MARK: - Action Button Style


### PR DESCRIPTION
## Summary
- update the shared root header icon view to use the primary tint instead of forcing white so custom themes respect system colors

## Testing
- not run (requires macOS UI to verify navigation glyph rendering)

------
https://chatgpt.com/codex/tasks/task_e_68d83457aa28832cb67eae3129553548