### PR TITLE
Wrap macOS glass tab bar in GlassEffectContainer

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -224,9 +224,11 @@ private struct MacRootTabBar: View {
 
     @available(macOS 26.0, *)
     private var glassTabBar: some View {
-        HStack(spacing: glassSpacing) {
-            ForEach(tabs, id: \.self) { tab in
-                glassTabButton(for: tab)
+        GlassEffectContainer(spacing: glassSpacing) {
+            HStack(spacing: glassSpacing) {
+                ForEach(tabs, id: \.self) { tab in
+                    glassTabButton(for: tab)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- wrap the macOS 26+ glass tab bar layout in a GlassEffectContainer to keep the buttons grouped under Liquid Glass
- retain the existing ForEach button generation and legacy tab bar behavior for older systems

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d839cad128832ca020e596f361e601