### PR TITLE
Adjust macOS tab label selection feedback

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -286,6 +286,7 @@ private struct MacTabLabel: View {
     var body: some View {
         VStack(spacing: 2) {
             Image(systemName: tab.systemImage)
+                .symbolVariant(isSelected ? .fill : .none)
                 .font(.system(size: 20, weight: .semibold))
             Text(tab.title)
                 .font(.system(size: 13, weight: .semibold, design: .rounded))
@@ -294,12 +295,17 @@ private struct MacTabLabel: View {
                 .layoutPriority(1)
         }
         .frame(maxWidth: .infinity)
-        .foregroundStyle(.primary)
-        .opacity(labelOpacity)
+        .overlay(alignment: .bottom) {
+            if isSelected {
+                selectionIndicator
+            }
+        }
     }
 
-    private var labelOpacity: Double {
-        isSelected ? 1 : 0.7
+    private var selectionIndicator: some View {
+        RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+            .frame(height: 3)
+            .padding(.horizontal, 10)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- remove the mac tab label's manual primary tint and opacity tweaks so system vibrancy can apply
- highlight the selected mac tab with SF Symbol fill variants and a shape indicator without introducing custom colors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d83a7a7b68832cbce9e13789308b70