### PR TITLE
fix: update mac toolbar background handling

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -135,7 +135,16 @@ private struct MacToolbarBackgroundModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if supportsTranslucency {
-            content
+            if #available(macOS 26.0, *) {
+                content
+                    .toolbarBackground(.hidden, for: .windowToolbar)
+            } else if #available(macOS 13.0, *) {
+                content
+                    .toolbarBackground(.visible, for: .windowToolbar)
+                    .toolbarBackground(theme.background, for: .windowToolbar)
+            } else {
+                content
+            }
         } else {
             if #available(macOS 13.0, *) {
                 content


### PR DESCRIPTION
## Summary
- gate the translucent toolbar background from macOS 26.0 and newer
- retain the themed toolbar background fallback for earlier releases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83b52b92c832c91afe3a0d86d7395