### PR TITLE
feat: refine mac glass tab effect

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -261,11 +261,13 @@ private struct MacRootTabBar: View {
         return Button {
             selectedTab = tab
         } label: {
+            let capsule = Capsule(style: .continuous)
             MacTabLabel(tab: tab, isSelected: isSelected)
                 .padding(.horizontal, metrics.horizontalPadding)
                 .frame(minWidth: buttonContentMinWidth, maxWidth: .infinity)
                 .frame(height: metrics.height)
-                .glassEffect()
+                .contentShape(capsule)
+                .glassEffect(.regular.interactive(), in: capsule)
         }
         .buttonStyle(.plain)
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- shape the macOS glass tab buttons with a reusable capsule
- scope the glass effect to the capsule for consistent hit testing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83d2183a0832c8ef797ee6e07b078