### PR TITLE
Fix mac toolbar background when translucency is available

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -135,7 +135,12 @@ private struct MacToolbarBackgroundModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if supportsTranslucency {
-            content
+            if #available(macOS 13.0, *) {
+                content
+                    .toolbarBackground(.hidden, for: .windowToolbar)
+            } else {
+                content
+            }
         } else {
             if #available(macOS 13.0, *) {
                 content


### PR DESCRIPTION
## Summary
- ensure the macOS toolbar background is explicitly hidden when OS 26 translucency is supported
- retain the themed window toolbar background for older systems without Liquid Glass

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d83dabdf3c832c99d4b960c1699874