### PR TITLE
Refine macOS root tab glass treatment

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -242,6 +242,11 @@ private struct MacRootTabBar: View {
         max(metrics.horizontalPadding / 2, 8)
     }
 
+    @available(macOS 26.0, *)
+    private var glassStyle: GlassEffectStyle {
+        .regular.interactive().tint(.clear)
+    }
+
     private func legacyTabButton(for tab: RootTabView.Tab) -> some View {
         Button {
             selectedTab = tab
@@ -272,7 +277,7 @@ private struct MacRootTabBar: View {
                 .frame(minWidth: buttonContentMinWidth, maxWidth: .infinity)
                 .frame(height: metrics.height)
                 .contentShape(capsule)
-                .glassEffect(.regular.interactive(), in: capsule)
+                .glassEffect(glassStyle, in: capsule)
         }
         .buttonStyle(.plain)
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
+++ b/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
@@ -21,6 +21,8 @@ struct TranslucentButtonStyle: ButtonStyle {
         var font: Font? = nil
         var overridesLabelForeground: Bool = true
 
+        var prefersTransparentFill: Bool = false
+
         static let standard = Metrics()
 
         static let rootActionIcon = Metrics(
@@ -98,7 +100,8 @@ struct TranslucentButtonStyle: ButtonStyle {
                 verticalPadding: 0,
                 pressedScale: 0.97,
                 font: nil,
-                overridesLabelForeground: false
+                overridesLabelForeground: false,
+                prefersTransparentFill: true
             )
         }
     }
@@ -189,6 +192,10 @@ struct TranslucentButtonStyle: ButtonStyle {
     }
 
     private func fillColor(for theme: AppTheme, isPressed: Bool) -> Color {
+        if metrics.prefersTransparentFill {
+            return .clear
+        }
+
         if theme == .system {
             return Color.white.opacity(isPressed ? 0.38 : 0.30)
         } else {


### PR DESCRIPTION
## Summary
- reuse a shared Liquid Glass style for macOS 26 root tab buttons while keeping the selection indicator overlay intact
- let the macOS root tab metrics request a transparent fill so Liquid Glass renders without an extra tint on modern systems

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d841796c68832cb2528d6548458a43