### PR TITLE
Fix macOS 26 glass tab button styling

### DIFF
--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -266,13 +266,13 @@ private struct MacRootTabBar: View {
         return Button {
             selectedTab = tab
         } label: {
-            let capsule = Capsule(style: .continuous)
-            MacTabLabel(tab: tab, isSelected: isSelected)
-                .padding(.horizontal, metrics.horizontalPadding)
-                .frame(minWidth: buttonContentMinWidth, maxWidth: .infinity)
-                .frame(height: metrics.height)
-                .contentShape(capsule)
-                .glassEffect(.regular.interactive(), in: capsule)
+            MacLiquidGlassTabButton(
+                tab: tab,
+                palette: palette,
+                metrics: metrics,
+                buttonContentMinWidth: buttonContentMinWidth,
+                isSelected: isSelected
+            )
         }
         .buttonStyle(.plain)
         .frame(minWidth: buttonMinWidth, maxWidth: .infinity)
@@ -283,6 +283,35 @@ private struct MacRootTabBar: View {
 
     private func accessibilityTraits(for tab: RootTabView.Tab) -> AccessibilityTraits {
         selectedTab == tab ? .isSelected : AccessibilityTraits()
+    }
+}
+
+@available(macOS 26.0, *)
+private struct MacLiquidGlassTabButton: View {
+    let tab: RootTabView.Tab
+    let palette: AppTheme.TabBarPalette
+    let metrics: TranslucentButtonStyle.Metrics
+    let buttonContentMinWidth: CGFloat
+    let isSelected: Bool
+
+    var body: some View {
+        let capsule = Capsule(style: .continuous)
+
+        MacTabLabel(tab: tab, isSelected: isSelected)
+            .padding(.horizontal, metrics.horizontalPadding)
+            .frame(minWidth: buttonContentMinWidth, maxWidth: .infinity)
+            .frame(height: metrics.height)
+            .contentShape(capsule)
+            .foregroundStyle(foregroundStyle)
+            .background {
+                capsule
+                    .fill(.clear)
+                    .glassEffect(.regular.interactive(), in: capsule)
+            }
+    }
+
+    private var foregroundStyle: Color {
+        isSelected ? palette.active : palette.inactive
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor the macOS 26 tab button to use a reusable liquid glass helper without the opaque fill
- add a dedicated MacLiquidGlassTabButton view that applies the glass effect to a clear capsule and uses the theme palette

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84a8a3ba0832cbc3e3287d1cbfe0f