### PR TITLE
feat: add Mac Liquid Glass navigation wrapper

### DIFF
--- a/OffshoreBudgeting/Systems/MacLiquidGlassNavigationBar.swift
+++ b/OffshoreBudgeting/Systems/MacLiquidGlassNavigationBar.swift
@@ -1,0 +1,127 @@
+#if os(macOS)
+import SwiftUI
+
+struct MacLiquidGlassNavigationBar<Content: View, Leading: View, Principal: View, Trailing: View>: View {
+    private let supportsTranslucency: Bool
+    private let content: () -> Content
+    private let leading: () -> Leading
+    private let principal: () -> Principal
+    private let trailing: () -> Trailing
+
+    init(
+        supportsTranslucency: Bool,
+        @ViewBuilder content: @escaping () -> Content,
+        @ViewBuilder leading: @escaping () -> Leading,
+        @ViewBuilder principal: @escaping () -> Principal,
+        @ViewBuilder trailing: @escaping () -> Trailing
+    ) {
+        self.supportsTranslucency = supportsTranslucency
+        self.content = content
+        self.leading = leading
+        self.principal = principal
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        navigationContainer
+            .toolbar {
+                if hasLeading {
+                    ToolbarItem(placement: .navigation) {
+                        glassToolbarItem(leading())
+                    }
+                }
+
+                if hasPrincipal {
+                    ToolbarItem(placement: .principal) {
+                        principal()
+                    }
+                }
+
+                if hasTrailing {
+                    ToolbarItem(placement: .primaryAction) {
+                        glassToolbarItem(trailing())
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var navigationContainer: some View {
+        if #available(macOS 13.0, *) {
+            NavigationStack {
+                content()
+            }
+            .modifier(MacNavigationGlassModifier(supportsTranslucency: supportsTranslucency))
+        } else {
+            NavigationView {
+                content()
+            }
+            .modifier(MacNavigationGlassModifier(supportsTranslucency: supportsTranslucency))
+        }
+    }
+
+    private var hasLeading: Bool { Leading.self != EmptyView.self }
+    private var hasPrincipal: Bool { Principal.self != EmptyView.self }
+    private var hasTrailing: Bool { Trailing.self != EmptyView.self }
+
+    @ViewBuilder
+    private func glassToolbarItem<V: View>(_ view: V) -> some View {
+        if supportsTranslucency {
+            if #available(macOS 26.0, *) {
+                view.glassEffect()
+            } else {
+                view
+            }
+        } else {
+            view
+        }
+    }
+}
+
+private struct MacNavigationGlassModifier: ViewModifier {
+    let supportsTranslucency: Bool
+
+    func body(content: Content) -> some View {
+        if supportsTranslucency {
+            if #available(macOS 26.0, *) {
+                content.glassEffect()
+            } else {
+                content
+            }
+        } else {
+            content
+        }
+    }
+}
+
+extension MacLiquidGlassNavigationBar where Leading == EmptyView, Principal == EmptyView, Trailing == EmptyView {
+    init(
+        supportsTranslucency: Bool,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.init(
+            supportsTranslucency: supportsTranslucency,
+            content: content,
+            leading: { EmptyView() },
+            principal: { EmptyView() },
+            trailing: { EmptyView() }
+        )
+    }
+}
+
+extension MacLiquidGlassNavigationBar where Leading == EmptyView, Trailing == EmptyView {
+    init(
+        supportsTranslucency: Bool,
+        @ViewBuilder content: @escaping () -> Content,
+        @ViewBuilder principal: @escaping () -> Principal
+    ) {
+        self.init(
+            supportsTranslucency: supportsTranslucency,
+            content: content,
+            leading: { EmptyView() },
+            principal: principal,
+            trailing: { EmptyView() }
+        )
+    }
+}
+#endif

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -92,31 +92,11 @@ struct RootTabView: View {
 
     #if os(macOS)
     private var macBody: some View {
-        Group {
-            if #available(macOS 13.0, *) {
-                NavigationStack {
-                    decoratedTabContent(for: selectedTab)
-                }
-            } else {
-                NavigationView {
-                    decoratedTabContent(for: selectedTab)
-                }
-            }
-        }
-        .toolbar {
-            macToolbar
-        }
-        .modifier(
-            MacToolbarBackgroundModifier(
-                theme: themeManager.selectedTheme,
-                supportsTranslucency: platformCapabilities.supportsOS26Translucency
-            )
-        )
-    }
-
-    @ToolbarContentBuilder
-    private var macToolbar: some ToolbarContent {
-        ToolbarItem(placement: .principal) {
+        MacLiquidGlassNavigationBar(
+            supportsTranslucency: platformCapabilities.supportsOS26Translucency
+        ) {
+            decoratedTabContent(for: selectedTab)
+        } principal: {
             MacRootTabBar(
                 selectedTab: $selectedTab,
                 palette: themeManager.selectedTheme.tabBarPalette,
@@ -124,6 +104,12 @@ struct RootTabView: View {
             )
             .frame(maxWidth: .infinity)
         }
+        .modifier(
+            MacToolbarBackgroundModifier(
+                theme: themeManager.selectedTheme,
+                supportsTranslucency: platformCapabilities.supportsOS26Translucency
+            )
+        )
     }
     #endif
 }
@@ -229,11 +215,9 @@ private struct MacRootTabBar: View {
 
     @available(macOS 26.0, *)
     private var glassTabBar: some View {
-        GlassEffectContainer(spacing: glassSpacing) {
-            HStack(spacing: glassSpacing) {
-                ForEach(tabs, id: \.self) { tab in
-                    glassTabButton(for: tab)
-                }
+        HStack(spacing: glassSpacing) {
+            ForEach(tabs, id: \.self) { tab in
+                glassTabButton(for: tab)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a reusable MacLiquidGlassNavigationBar wrapper that applies Liquid Glass to macOS navigation chrome
- integrate the wrapper into RootTabView and remove the extra GlassEffectContainer from the tab bar

## Testing
- not run (macOS UI tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84bacbaf0832ca9ea98385495a712