### PR TITLE
fix: anchor mac segmented controls to capsules

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -12,6 +12,7 @@ import CoreData
 import Combine
 #if os(macOS)
 import AppKit
+import ObjectiveC
 #endif
 // MARK: - BudgetDetailsView
 /// Shows a budget header, filters, and a segmented control to switch between
@@ -873,7 +874,11 @@ private struct EqualWidthSegmentApplier: NSViewRepresentable {
     }
 
     private func applyEqualWidthIfNeeded(from view: NSView) {
-        guard let segmented = findSegmentedControl(from: view) else { return }
+        guard
+            let segmented = findSegmentedControl(from: view),
+            let container = findCapsuleContainer(for: segmented)
+        else { return }
+
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
         } else {
@@ -886,19 +891,48 @@ private struct EqualWidthSegmentApplier: NSViewRepresentable {
                 segmented.setWidth(equalWidth, forSegment: index)
             }
         }
+
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        // Expand to fill container when possible
-        if let superview = segmented.superview {
-            segmented.translatesAutoresizingMaskIntoConstraints = false
-            if segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive == false {
-                segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive = true
-            }
-            if segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive == false {
-                segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive = true
-            }
-        }
+        container.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        container.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        segmented.translatesAutoresizingMaskIntoConstraints = false
+        activateConstraintsIfNeeded(for: segmented, in: container)
+
+        container.layoutSubtreeIfNeeded()
         segmented.invalidateIntrinsicContentSize()
+    }
+
+    private func activateConstraintsIfNeeded(for segmented: NSSegmentedControl, in container: NSView) {
+        let cache = constraintCache(for: segmented)
+        if cache.container !== container {
+            cache.deactivateAll()
+            cache.container = container
+        }
+
+        if cache.leading == nil {
+            let constraint = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            constraint.identifier = "EqualWidthLeading"
+            cache.leading = constraint
+        }
+
+        if cache.trailing == nil {
+            let constraint = container.trailingAnchor.constraint(equalTo: segmented.trailingAnchor)
+            constraint.identifier = "EqualWidthTrailing"
+            cache.trailing = constraint
+        }
+
+        if cache.width == nil {
+            let constraint = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
+            constraint.identifier = "EqualWidthMatchWidth"
+            cache.width = constraint
+        }
+
+        let constraintsToActivate = [cache.leading, cache.trailing, cache.width].compactMap { $0 }.filter { $0.isActive == false }
+        if constraintsToActivate.isEmpty == false {
+            NSLayoutConstraint.activate(constraintsToActivate)
+        }
     }
 
     private func findSegmentedControl(from view: NSView) -> NSSegmentedControl? {
@@ -912,6 +946,56 @@ private struct EqualWidthSegmentApplier: NSViewRepresentable {
             if let found = searchSegmented(in: sub) { return found }
         }
         return nil
+    }
+
+    private func findCapsuleContainer(for segmented: NSSegmentedControl) -> NSView? {
+        var current: NSView? = segmented.superview
+        var encounteredHostingAncestor = false
+
+        while let candidate = current {
+            if isHostingView(candidate) {
+                encounteredHostingAncestor = true
+            } else if encounteredHostingAncestor {
+                return candidate
+            }
+            current = candidate.superview
+        }
+
+        return segmented.superview
+    }
+
+    private func isHostingView(_ view: NSView) -> Bool {
+        let className = NSStringFromClass(type(of: view))
+        return className.contains("NSHostingView") || className.contains("ViewHost") || className.contains("HostingView")
+    }
+
+    private func constraintCache(for segmented: NSSegmentedControl) -> ConstraintCache {
+        if let existing = objc_getAssociatedObject(segmented, &AssociatedKeys.constraintCache) as? ConstraintCache {
+            return existing
+        }
+        let storage = ConstraintCache()
+        objc_setAssociatedObject(segmented, &AssociatedKeys.constraintCache, storage, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return storage
+    }
+
+    private final class ConstraintCache {
+        var container: NSView?
+        var leading: NSLayoutConstraint?
+        var trailing: NSLayoutConstraint?
+        var width: NSLayoutConstraint?
+
+        func deactivateAll() {
+            [leading, trailing, width].forEach { constraint in
+                constraint?.isActive = false
+            }
+            leading = nil
+            trailing = nil
+            width = nil
+        }
+    }
+
+    private enum AssociatedKeys {
+        static var constraintCache = "BudgetDetailsEqualWidthCache"
     }
 }
 #endif

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -19,6 +19,10 @@ import SwiftUI
 import CoreData
 import Foundation
 import Combine
+#if os(macOS)
+import AppKit
+import ObjectiveC
+#endif
 
 // MARK: - HomeView
 struct HomeView: View {
@@ -1204,7 +1208,11 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
     }
 
     private func applyEqualWidthIfNeeded(from view: NSView) {
-        guard let segmented = findSegmentedControl(from: view) else { return }
+        guard
+            let segmented = findSegmentedControl(from: view),
+            let container = findCapsuleContainer(for: segmented)
+        else { return }
+
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
         } else {
@@ -1215,24 +1223,51 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
             let equalWidth = totalWidth / CGFloat(count)
             for index in 0..<count { segmented.setWidth(equalWidth, forSegment: index) }
         }
+
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        // Pin to fill its container if possible so it expands to max width.
-        if let superview = segmented.superview {
-            segmented.translatesAutoresizingMaskIntoConstraints = false
-            if segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive == false {
-                segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive = true
-            }
-            if segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive == false {
-                segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive = true
-            }
-        }
+        container.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        container.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        segmented.translatesAutoresizingMaskIntoConstraints = false
+        activateConstraintsIfNeeded(for: segmented, in: container)
+
+        container.layoutSubtreeIfNeeded()
         segmented.invalidateIntrinsicContentSize()
     }
 
+    private func activateConstraintsIfNeeded(for segmented: NSSegmentedControl, in container: NSView) {
+        let cache = constraintCache(for: segmented)
+        if cache.container !== container {
+            cache.deactivateAll()
+            cache.container = container
+        }
+
+        if cache.leading == nil {
+            let constraint = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            constraint.identifier = "HomeEqualWidthLeading"
+            cache.leading = constraint
+        }
+
+        if cache.trailing == nil {
+            let constraint = container.trailingAnchor.constraint(equalTo: segmented.trailingAnchor)
+            constraint.identifier = "HomeEqualWidthTrailing"
+            cache.trailing = constraint
+        }
+
+        if cache.width == nil {
+            let constraint = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
+            constraint.identifier = "HomeEqualWidthMatchWidth"
+            cache.width = constraint
+        }
+
+        let constraintsToActivate = [cache.leading, cache.trailing, cache.width].compactMap { $0 }.filter { $0.isActive == false }
+        if constraintsToActivate.isEmpty == false {
+            NSLayoutConstraint.activate(constraintsToActivate)
+        }
+    }
+
     private func findSegmentedControl(from view: NSView) -> NSSegmentedControl? {
-        // Prefer searching siblings/descendants of the immediate superview, because
-        // this representable is attached as a background.
         guard let root = view.superview else { return nil }
         return searchSegmented(in: root)
     }
@@ -1243,6 +1278,56 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
             if let found = searchSegmented(in: sub) { return found }
         }
         return nil
+    }
+
+    private func findCapsuleContainer(for segmented: NSSegmentedControl) -> NSView? {
+        var current: NSView? = segmented.superview
+        var encounteredHostingAncestor = false
+
+        while let candidate = current {
+            if isHostingView(candidate) {
+                encounteredHostingAncestor = true
+            } else if encounteredHostingAncestor {
+                return candidate
+            }
+            current = candidate.superview
+        }
+
+        return segmented.superview
+    }
+
+    private func isHostingView(_ view: NSView) -> Bool {
+        let className = NSStringFromClass(type(of: view))
+        return className.contains("NSHostingView") || className.contains("ViewHost") || className.contains("HostingView")
+    }
+
+    private func constraintCache(for segmented: NSSegmentedControl) -> ConstraintCache {
+        if let existing = objc_getAssociatedObject(segmented, &AssociatedKeys.constraintCache) as? ConstraintCache {
+            return existing
+        }
+        let storage = ConstraintCache()
+        objc_setAssociatedObject(segmented, &AssociatedKeys.constraintCache, storage, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return storage
+    }
+
+    private final class ConstraintCache {
+        var container: NSView?
+        var leading: NSLayoutConstraint?
+        var trailing: NSLayoutConstraint?
+        var width: NSLayoutConstraint?
+
+        func deactivateAll() {
+            [leading, trailing, width].forEach { constraint in
+                constraint?.isActive = false
+            }
+            leading = nil
+            trailing = nil
+            width = nil
+        }
+    }
+
+    private enum AssociatedKeys {
+        static var constraintCache = "HomeEqualWidthCache"
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- update the macOS segmented control helpers in BudgetDetailsView and HomeView to anchor controls to the capsule container and reuse constraints
- lower the horizontal hugging/compression resistance for both the segmented control and container so they resize with the capsule shell
- trigger layout updates after constraint changes to keep equal-width segments in sync with window resizing

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8a17d6fc8832cbfe2af4e45af6b0c