### PR TITLE
fix: keep segmented controls aligned with capsule containers

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1208,16 +1208,52 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
         }
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        // Pin to fill its container if possible so it expands to max width.
-        if let superview = segmented.superview {
-            segmented.translatesAutoresizingMaskIntoConstraints = false
-            if segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive == false {
-                segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive = true
-            }
-            if segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive == false {
-                segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive = true
-            }
+        let cache = constraintCache(for: segmented)
+        let container = findCapsuleContainer(for: segmented) ?? segmented.superview
+
+        if cache.container !== container {
+            cache.deactivateAll()
+            cache.container = container
         }
+
+        if let container {
+            segmented.translatesAutoresizingMaskIntoConstraints = false
+
+            if cache.leading == nil {
+                let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+                leading.priority = .required
+                leading.isActive = true
+                cache.leading = leading
+            } else {
+                cache.leading?.isActive = true
+            }
+
+            if cache.trailing == nil {
+                let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+                trailing.priority = .required
+                trailing.isActive = true
+                cache.trailing = trailing
+            } else {
+                cache.trailing?.isActive = true
+            }
+
+            if container !== segmented.superview {
+                if cache.width == nil {
+                    let width = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
+                    width.priority = .required
+                    width.isActive = true
+                    cache.width = width
+                } else {
+                    cache.width?.isActive = true
+                }
+            } else if let width = cache.width {
+                width.isActive = false
+                cache.width = nil
+            }
+
+            container.layoutSubtreeIfNeeded()
+        }
+
         segmented.invalidateIntrinsicContentSize()
     }
 


### PR DESCRIPTION
## Summary
- update the Home view segment equal-width helper to anchor constraints to the capsule container and re-layout immediately
- mirror the container-aware constraint handling for the Budget sort toggle so both controls expand with their capsules

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8b28ac458832ca3e50f1952140a67