### PR TITLE
feat: update mac segmented picker styling

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -346,10 +346,8 @@ private extension BudgetDetailsView {
                 .frame(maxWidth: .infinity)
 #if os(macOS)
                 .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
+                .macSegmentedAppearance()
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -736,11 +734,9 @@ private struct FilterBar: View {
             .equalWidthSegments()
 #if os(macOS)
             .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
             .frame(maxWidth: .infinity)
+            .macSegmentedAppearance()
         }
         .frame(maxWidth: .infinity)
         .ub_onChange(of: startDate) { onChanged() }
@@ -853,18 +849,22 @@ private struct EqualWidthSegmentApplier: UIViewRepresentable {
 }
 #elseif os(macOS)
 private struct EqualWidthSegmentApplier: NSViewRepresentable {
+    @Environment(\.macSegmentedAppearanceConfiguration) private var segmentedAppearanceConfiguration
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         view.alphaValue = 0.0
-        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: view) }
+        let configuration = segmentedAppearanceConfiguration
+        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: view, configuration: configuration) }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: nsView) }
+        let configuration = segmentedAppearanceConfiguration
+        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: nsView, configuration: configuration) }
     }
 
-    private func applyEqualWidthIfNeeded(from view: NSView) {
+    private func applyEqualWidthIfNeeded(from view: NSView, configuration: MacSegmentedAppearanceConfiguration) {
         guard let segmented = findSegmentedControl(from: view) else { return }
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
@@ -926,6 +926,7 @@ private struct EqualWidthSegmentApplier: NSViewRepresentable {
             container.layoutSubtreeIfNeeded()
         }
 
+        MacSegmentedControlStyler.applyStyle(configuration, to: segmented)
         segmented.invalidateIntrinsicContentSize()
     }
 

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -19,6 +19,9 @@ import SwiftUI
 import CoreData
 import Foundation
 import Combine
+#if os(macOS)
+import AppKit
+#endif
 
 // MARK: - HomeView
 struct HomeView: View {
@@ -703,10 +706,8 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity)
 #if os(macOS)
                     .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
+                    .macSegmentedAppearance()
                 }
 
                 // Filter bar (sort options)
@@ -723,10 +724,8 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity)
 #if os(macOS)
                     .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
+                    .macSegmentedAppearance()
                 }
 
                 // Always-offer Add button when no budget exists so users can
@@ -1183,18 +1182,22 @@ private struct HomeEqualWidthSegmentApplier: UIViewRepresentable {
 }
 #elseif os(macOS)
 private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
+    @Environment(\.macSegmentedAppearanceConfiguration) private var segmentedAppearanceConfiguration
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         view.alphaValue = 0.0
-        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: view) }
+        let configuration = segmentedAppearanceConfiguration
+        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: view, configuration: configuration) }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: nsView) }
+        let configuration = segmentedAppearanceConfiguration
+        DispatchQueue.main.async { applyEqualWidthIfNeeded(from: nsView, configuration: configuration) }
     }
 
-    private func applyEqualWidthIfNeeded(from view: NSView) {
+    private func applyEqualWidthIfNeeded(from view: NSView, configuration: MacSegmentedAppearanceConfiguration) {
         guard let segmented = findSegmentedControl(from: view) else { return }
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
@@ -1254,6 +1257,7 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
             container.layoutSubtreeIfNeeded()
         }
 
+        MacSegmentedControlStyler.applyStyle(configuration, to: segmented)
         segmented.invalidateIntrinsicContentSize()
     }
 
@@ -1324,7 +1328,146 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
     }
 
 }
+#if os(macOS)
+// MARK: - macOS Segmented Appearance Support
+
+struct MacSegmentedAppearanceConfiguration {
+    enum Style {
+        case liquidGlass(accent: Color?)
+        case legacy(contentTint: Color, background: Color, divider: Color)
+    }
+
+    let style: Style
+
+    static var legacyDefault: MacSegmentedAppearanceConfiguration {
+        MacSegmentedAppearanceConfiguration(
+            style: .legacy(
+                contentTint: Color(nsColor: .secondaryLabelColor),
+                background: Color(nsColor: .controlBackgroundColor),
+                divider: Color(nsColor: .separatorColor)
+            )
+        )
+    }
+
+    var usesLiquidGlass: Bool {
+        if case .liquidGlass = style { return true }
+        return false
+    }
+
+    var contentTintColor: Color? {
+        switch style {
+        case .liquidGlass(let accent):
+            return accent
+        case .legacy(let tint, _, _):
+            return tint
+        }
+    }
+
+    var backgroundColor: Color? {
+        switch style {
+        case .liquidGlass:
+            return nil
+        case .legacy(_, let background, _):
+            return background
+        }
+    }
+
+    var dividerColor: Color? {
+        switch style {
+        case .liquidGlass:
+            return nil
+        case .legacy(_, _, let divider):
+            return divider
+        }
+    }
+}
+
+private struct MacSegmentedAppearanceConfigurationKey: EnvironmentKey {
+    static let defaultValue: MacSegmentedAppearanceConfiguration = .legacyDefault
+}
+
+extension EnvironmentValues {
+    var macSegmentedAppearanceConfiguration: MacSegmentedAppearanceConfiguration {
+        get { self[MacSegmentedAppearanceConfigurationKey.self] }
+        set { self[MacSegmentedAppearanceConfigurationKey.self] = newValue }
+    }
+}
+
+struct MacSegmentedAppearanceModifier: ViewModifier {
+    @Environment(\.platformCapabilities) private var capabilities
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var themeManager: ThemeManager
+
+    func body(content: Content) -> some View {
+        content.environment(\.macSegmentedAppearanceConfiguration, resolvedConfiguration)
+    }
+
+    private var resolvedConfiguration: MacSegmentedAppearanceConfiguration {
+        if capabilities.supportsOS26Translucency {
+            let accent: Color?
+            if colorScheme == .dark {
+                accent = themeManager.selectedTheme.glassPalette.accent
+            } else {
+                accent = nil
+            }
+            return MacSegmentedAppearanceConfiguration(style: .liquidGlass(accent: accent))
+        } else {
+            return MacSegmentedAppearanceConfiguration.legacyDefault
+        }
+    }
+}
+
+extension View {
+    func macSegmentedAppearance() -> some View { modifier(MacSegmentedAppearanceModifier()) }
+}
+
+enum MacSegmentedControlStyler {
+    static func applyStyle(_ configuration: MacSegmentedAppearanceConfiguration, to segmented: NSSegmentedControl) {
+        segmented.contentTintColor = nsColor(from: configuration.contentTintColor)
+
+        if configuration.usesLiquidGlass {
+            segmented.drawsBackground = false
+            segmented.wantsLayer = false
+            segmented.layer?.backgroundColor = nil
+            segmented.layer?.cornerRadius = 0
+            segmented.layer?.masksToBounds = false
+            applyDividerColor(nil, to: segmented)
+        } else {
+            segmented.drawsBackground = true
+            segmented.wantsLayer = true
+            segmented.layer?.masksToBounds = true
+            segmented.layer?.cornerRadius = segmented.bounds.height / 2
+            segmented.layer?.backgroundColor = cgColor(from: configuration.backgroundColor)
+            applyDividerColor(configuration.dividerColor, to: segmented)
+        }
+    }
+
+    private static func applyDividerColor(_ color: Color?, to segmented: NSSegmentedControl) {
+        let dividerColor = nsColor(from: color)
+        let segmentCount = segmented.segmentCount
+        guard segmentCount > 1 else { return }
+        for index in 0..<(segmentCount - 1) {
+            segmented.setDividerColor(dividerColor, forSegment: index)
+        }
+    }
+
+    private static func nsColor(from color: Color?) -> NSColor? {
+        guard let color else { return nil }
+        let platformColor = NSColor(color)
+        return platformColor.usingColorSpace(.deviceRGB) ?? platformColor
+    }
+
+    private static func cgColor(from color: Color?) -> CGColor? {
+        guard let nsColor = nsColor(from: color) else { return nil }
+        return nsColor.cgColor
+    }
+}
+#else
+extension View {
+    func macSegmentedAppearance() -> some View { self }
+}
 #endif
+
 
 // MARK: - Home Header Summary
 private struct HomeHeaderContextSummary: View {


### PR DESCRIPTION
## Summary
- add a macOS-specific segmented appearance modifier and helper styler so NSSegmentedControl picks Liquid Glass or legacy backgrounds
- apply the reusable appearance modifier to Home and Budget segmented pickers to keep macOS 26 light mode neutral while dark mode stays high contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8b53eaa90832cae0c5a2889cec33b