### PR TITLE
fix: reuse cached segment constraints on macOS

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -880,16 +880,52 @@ private struct EqualWidthSegmentApplier: NSViewRepresentable {
         }
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        // Expand to fill container when possible
-        if let superview = segmented.superview {
-            segmented.translatesAutoresizingMaskIntoConstraints = false
-            if segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive == false {
-                segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive = true
-            }
-            if segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive == false {
-                segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive = true
+
+        guard let container = segmented.superview else {
+            segmented.invalidateIntrinsicContentSize()
+            return
+        }
+
+        segmented.translatesAutoresizingMaskIntoConstraints = false
+
+        let cache = constraintCache(for: segmented)
+        if let cachedContainer = cache.container, cachedContainer !== container {
+            cache.deactivateAll()
+        }
+        cache.container = container
+
+        if let leading = cache.leading {
+            let matches = (leading.firstItem as? NSView) === segmented && (leading.secondItem as? NSView) === container
+            if !matches {
+                leading.isActive = false
+                cache.leading = nil
             }
         }
+
+        if let trailing = cache.trailing {
+            let matches = (trailing.firstItem as? NSView) === segmented && (trailing.secondItem as? NSView) === container
+            if !matches {
+                trailing.isActive = false
+                cache.trailing = nil
+            }
+        }
+
+        if cache.leading == nil {
+            let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            leading.isActive = true
+            cache.leading = leading
+        } else {
+            cache.leading?.isActive = true
+        }
+
+        if cache.trailing == nil {
+            let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+            trailing.isActive = true
+            cache.trailing = trailing
+        } else {
+            cache.trailing?.isActive = true
+        }
+
         segmented.invalidateIntrinsicContentSize()
     }
 

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1208,16 +1208,52 @@ private struct HomeEqualWidthSegmentApplier: NSViewRepresentable {
         }
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        // Pin to fill its container if possible so it expands to max width.
-        if let superview = segmented.superview {
-            segmented.translatesAutoresizingMaskIntoConstraints = false
-            if segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive == false {
-                segmented.leadingAnchor.constraint(equalTo: superview.leadingAnchor).isActive = true
-            }
-            if segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive == false {
-                segmented.trailingAnchor.constraint(equalTo: superview.trailingAnchor).isActive = true
+
+        guard let container = segmented.superview else {
+            segmented.invalidateIntrinsicContentSize()
+            return
+        }
+
+        segmented.translatesAutoresizingMaskIntoConstraints = false
+
+        let cache = constraintCache(for: segmented)
+        if let cachedContainer = cache.container, cachedContainer !== container {
+            cache.deactivateAll()
+        }
+        cache.container = container
+
+        if let leading = cache.leading {
+            let matches = (leading.firstItem as? NSView) === segmented && (leading.secondItem as? NSView) === container
+            if !matches {
+                leading.isActive = false
+                cache.leading = nil
             }
         }
+
+        if let trailing = cache.trailing {
+            let matches = (trailing.firstItem as? NSView) === segmented && (trailing.secondItem as? NSView) === container
+            if !matches {
+                trailing.isActive = false
+                cache.trailing = nil
+            }
+        }
+
+        if cache.leading == nil {
+            let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            leading.isActive = true
+            cache.leading = leading
+        } else {
+            cache.leading?.isActive = true
+        }
+
+        if cache.trailing == nil {
+            let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+            trailing.isActive = true
+            cache.trailing = trailing
+        } else {
+            cache.trailing?.isActive = true
+        }
+
         segmented.invalidateIntrinsicContentSize()
     }
 


### PR DESCRIPTION
## Summary
- update macOS segmented-control appliers to reuse cached leading/trailing constraints for the current container
- clear cached constraints whenever the segmented control moves to a new container to avoid duplicates

## Testing
- not run (UI changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8be471898832ca4ad615fca0de789