### PR TITLE
Fix mac segmented picker tint to respect platform styles

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -347,9 +347,8 @@ private extension BudgetDetailsView {
 #if os(macOS)
                 .controlSize(.large)
 
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
+                .ub_segmentedControlTint(for: capabilities)
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -708,6 +707,7 @@ private struct FilterBar: View {
     let onResetDate: () -> Void
 
     @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
 
     var body: some View {
         GlassCapsuleContainer(
@@ -737,15 +737,29 @@ private struct FilterBar: View {
 #if os(macOS)
             .controlSize(.large)
 
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
 #endif
+            .ub_segmentedControlTint(for: capabilities)
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)
         .ub_onChange(of: startDate) { onChanged() }
         .ub_onChange(of: endDate) { onChanged() }
         .ub_onChange(of: sort) { onChanged() }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func ub_segmentedControlTint(for capabilities: PlatformCapabilities) -> some View {
+#if os(macOS)
+        if #available(macOS 26.0, *), capabilities.supportsOS26Translucency {
+            self
+        } else {
+            self.tint(Color(nsColor: NSColor.controlAccentColor))
+        }
+#else
+        self
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- inject platform capability checks into the macOS segmented controls so Liquid Glass builds skip forced tinting
- add a reusable helper to apply the system neutral tint for legacy macOS segmented controls and reuse it across pickers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8bef569f0832ca69b9554819cb1c2