### PR TITLE
Align macOS empty shell segmented styling with iOS

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -701,12 +701,6 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-#if os(macOS)
-                    .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
                 }
 
                 // Filter bar (sort options)
@@ -721,12 +715,6 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-#if os(macOS)
-                    .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
                 }
 
                 // Always-offer Add button when no budget exists so users can


### PR DESCRIPTION
## Summary
- remove macOS-only control sizing and tint overrides from the empty period segmented controls so all platforms share the same layout
- keep HomeGlassCapsuleContainer using its existing glassEffect path when OS 26 translucency is available

## Testing
- not run (requires macOS build tools)


------
https://chatgpt.com/codex/tasks/task_e_68d920a79b40832c82c76076fb2654bb