### PR TITLE
fix: align budget controls across platforms

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -344,12 +344,8 @@ private extension BudgetDetailsView {
                 .pickerStyle(.segmented)
                 .equalWidthSegments()
                 .frame(maxWidth: .infinity)
-#if os(macOS)
                 .controlSize(.large)
-
                 .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -734,12 +730,8 @@ private struct FilterBar: View {
             }
             .pickerStyle(.segmented)
             .equalWidthSegments()
-#if os(macOS)
             .controlSize(.large)
-
             .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- remove macOS-only conditional wrappers so segmented pickers share control sizing and tint across platforms
- rely on the existing GlassCapsuleContainer availability checks to manage Liquid Glass on supported OS versions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d92474ca6c832caeb42c6d9285f0ac