### PR TITLE
fix: align budget header padding across platforms

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -639,23 +639,6 @@ struct HomeView: View {
 
             case .loaded(let summaries):
                 if let first = summaries.first {
-#if os(macOS)
-                    BudgetDetailsView(
-                        budgetObjectID: first.id,
-                        periodNavigation: .init(
-                            title: title(for: vm.selectedDate),
-                            onAdjust: { delta in vm.adjustSelectedPeriod(by: delta) }
-                        ),
-                        displaysBudgetTitle: false,
-                        showsIncomeSavingsGrid: false,
-                        onSegmentChange: { newSegment in
-                            self.selectedSegment = newSegment
-                        }
-                    )
-                    .id(first.id)
-                    .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-#else
                     BudgetDetailsView(
                         budgetObjectID: first.id,
                         periodNavigation: .init(
@@ -672,7 +655,6 @@ struct HomeView: View {
                     .id(first.id)
                     .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-#endif
                 } else {
                     emptyPeriodShell(proxy: proxy)
                 }


### PR DESCRIPTION
## Summary
- update HomeView to remove the macOS conditional wrapper around BudgetDetailsView
- always provide the shared headerTopPadding so macOS adopts the same spacing as iOS/iPadOS

## Testing
- xcodebuild -scheme OffshoreBudgeting-macOS -project OffshoreBudgeting.xcodeproj build (fails: xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d92695b6dc832cac4eae1c2ae335fe