### PR TITLE
fix(view): gate mac tint behind legacy capabilities

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -36,6 +36,7 @@ struct BudgetDetailsView: View {
 
     // MARK: Theme
     @EnvironmentObject private var themeManager: ThemeManager
+
     @Environment(\.responsiveLayoutContext) private var layoutContext
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.platformCapabilities) private var capabilities
@@ -346,9 +347,10 @@ private extension BudgetDetailsView {
                 .frame(maxWidth: .infinity)
 #if os(macOS)
                 .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
+                .macLegacyAccentTintIfNeeded(
+                    capabilities: capabilities,
+                    accentColor: themeManager.selectedTheme.glassPalette.accent
+                )
 #endif
             }
             .padding(.horizontal, DS.Spacing.l)
@@ -708,6 +710,7 @@ private struct FilterBar: View {
     let onResetDate: () -> Void
 
     @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
 
     var body: some View {
         GlassCapsuleContainer(
@@ -736,9 +739,10 @@ private struct FilterBar: View {
             .equalWidthSegments()
 #if os(macOS)
             .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
+            .macLegacyAccentTintIfNeeded(
+                capabilities: capabilities,
+                accentColor: themeManager.selectedTheme.glassPalette.accent
+            )
 #endif
             .frame(maxWidth: .infinity)
         }

--- a/OffshoreBudgeting/Views/Components/MacLegacyAccentTint.swift
+++ b/OffshoreBudgeting/Views/Components/MacLegacyAccentTint.swift
@@ -1,0 +1,17 @@
+#if os(macOS)
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func macLegacyAccentTintIfNeeded(
+        capabilities: PlatformCapabilities,
+        accentColor: Color
+    ) -> some View {
+        if capabilities.supportsOS26Translucency {
+            self
+        } else {
+            self.tint(accentColor)
+        }
+    }
+}
+#endif

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -703,9 +703,10 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity)
 #if os(macOS)
                     .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
+                    .macLegacyAccentTintIfNeeded(
+                        capabilities: capabilities,
+                        accentColor: themeManager.selectedTheme.glassPalette.accent
+                    )
 #endif
                 }
 
@@ -723,9 +724,10 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity)
 #if os(macOS)
                     .controlSize(.large)
-
-                    .tint(themeManager.selectedTheme.glassPalette.accent)
-
+                    .macLegacyAccentTintIfNeeded(
+                        capabilities: capabilities,
+                        accentColor: themeManager.selectedTheme.glassPalette.accent
+                    )
 #endif
                 }
 


### PR DESCRIPTION
## Summary
- guard macOS segmented control tinting behind the existing platform capabilities check so macOS 26+ can keep system liquid glass colours
- add a reusable helper for applying the legacy accent tint and adopt it in HomeView and BudgetDetailsView segmented pickers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d92ee1d364832ca9c5ab69cb64f4b8