### PR TITLE
feat: align mac segmented control with Liquid Glass

### DIFF
--- a/OffshoreBudgeting/Views/Components/SegmentedControlGlassContainer.swift
+++ b/OffshoreBudgeting/Views/Components/SegmentedControlGlassContainer.swift
@@ -54,11 +54,17 @@ extension View {
 }
 
 private struct SegmentedControlEqualWidthModifier: ViewModifier {
+    @EnvironmentObject private var themeManager: ThemeManager
+
     func body(content: Content) -> some View {
 #if os(iOS)
-        content.background(SegmentedControlEqualWidthApplier())
+        content.background(
+            SegmentedControlEqualWidthApplier(palette: themeManager.selectedTheme.glassPalette)
+        )
 #elif os(macOS)
-        content.background(SegmentedControlEqualWidthApplier())
+        content.background(
+            SegmentedControlEqualWidthApplier(palette: themeManager.selectedTheme.glassPalette)
+        )
 #else
         content
 #endif
@@ -67,6 +73,8 @@ private struct SegmentedControlEqualWidthModifier: ViewModifier {
 
 #if os(iOS)
 private struct SegmentedControlEqualWidthApplier: UIViewRepresentable {
+    let palette: AppTheme.GlassConfiguration.Palette
+
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.isUserInteractionEnabled = false
@@ -87,6 +95,7 @@ private struct SegmentedControlEqualWidthApplier: UIViewRepresentable {
         segmented.apportionsSegmentWidthsByContent = false
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        applyMacCatalystLiquidGlassIfNeeded(to: segmented)
         segmented.invalidateIntrinsicContentSize()
     }
 
@@ -100,9 +109,21 @@ private struct SegmentedControlEqualWidthApplier: UIViewRepresentable {
         }
         return nil
     }
+
+    private func applyMacCatalystLiquidGlassIfNeeded(to segmented: UISegmentedControl) {
+#if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 26.0, *) {
+            segmented.selectedSegmentTintColor = UIColor(palette.accent)
+            segmented.tintColor = UIColor(palette.accent)
+            segmented.backgroundColor = UIColor(palette.shadow).withAlphaComponent(0.12)
+        }
+#endif
+    }
 }
-#elseif os(macOS)
+#elif os(macOS)
 private struct SegmentedControlEqualWidthApplier: NSViewRepresentable {
+    let palette: AppTheme.GlassConfiguration.Palette
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
@@ -139,6 +160,7 @@ private struct SegmentedControlEqualWidthApplier: NSViewRepresentable {
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         applyCapsulePinning(to: segmented, context: context)
+        applyLiquidGlassAppearanceIfNeeded(to: segmented)
         segmented.invalidateIntrinsicContentSize()
     }
 
@@ -205,6 +227,20 @@ private struct SegmentedControlEqualWidthApplier: NSViewRepresentable {
             if layer.mask != nil { return true }
         }
         return false
+    }
+
+    private func applyLiquidGlassAppearanceIfNeeded(to segmented: NSSegmentedControl) {
+        guard #available(macOS 26.0, *) else { return }
+        segmented.segmentStyle = .capsule
+        segmented.bezelStyle = .rounded
+        segmented.contentTintColor = NSColor(palette.accent)
+
+        if segmented.responds(to: Selector(("setContentBorderColor:forSegment:"))) {
+            let rimColor = NSColor(palette.rim).withAlphaComponent(0.30)
+            for index in 0..<segmented.segmentCount {
+                segmented.setContentBorderColor(rimColor, forSegment: index)
+            }
+        }
     }
 
     final class Coordinator {


### PR DESCRIPTION
## Summary
- opt the macOS/catalyst segmented control representable into the Liquid Glass appearance for OS 26
- source tint colors from the selected theme glass palette so mac accents match the rest of the platform

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d935aaef24832c9140ea9bd5c7fb3e