### PR TITLE
feat: share glass capsule container layout

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -749,50 +749,6 @@ private struct FilterBar: View {
     }
 }
 
-// MARK: - Shared Glass Capsule Container
-private struct GlassCapsuleContainer<Content: View>: View {
-    @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.responsiveLayoutContext) private var layoutContext
-    @Environment(\.platformCapabilities) private var capabilities
-
-    private let content: Content
-    private let horizontalPadding: CGFloat
-    private let verticalPadding: CGFloat
-    private let contentAlignment: Alignment
-
-    init(
-        horizontalPadding: CGFloat = DS.Spacing.l,
-        verticalPadding: CGFloat = DS.Spacing.m,
-        alignment: Alignment = .leading,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.content = content()
-        self.horizontalPadding = horizontalPadding
-        self.verticalPadding = verticalPadding
-        self.contentAlignment = alignment
-    }
-
-    var body: some View {
-        let capsule = Capsule(style: .continuous)
-
-        let decorated = content
-            .frame(maxWidth: .infinity, alignment: contentAlignment)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, verticalPadding)
-            .contentShape(capsule)
-
-        if #available(iOS 26.0, macOS 26.0, tvOS 18.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
-            GlassEffectContainer {
-                decorated
-                    .glassEffect(.regular.interactive(), in: capsule)
-            }
-        } else {
-            // Classic OS: render inline with no capsule background
-            decorated
-        }
-    }
-}
-
 private extension View {
     func segmentedFill() -> some View {
         frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+// MARK: - GlassCapsuleContainer
+struct GlassCapsuleContainer<Content: View>: View {
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.responsiveLayoutContext) private var layoutContext
+    @Environment(\.platformCapabilities) private var capabilities
+
+    private let content: Content
+    private let horizontalPadding: CGFloat
+    private let verticalPadding: CGFloat
+    private let contentAlignment: Alignment
+
+    init(
+        horizontalPadding: CGFloat = DS.Spacing.l,
+        verticalPadding: CGFloat = DS.Spacing.m,
+        alignment: Alignment = .leading,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.content = content()
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+        self.contentAlignment = alignment
+    }
+
+    var body: some View {
+        let _ = themeManager
+        let _ = layoutContext
+
+        let capsule = Capsule(style: .continuous)
+        let decorated = content
+            .frame(maxWidth: .infinity, alignment: contentAlignment)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .contentShape(capsule)
+
+        if #available(iOS 26.0, macOS 26.0, tvOS 18.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
+            GlassEffectContainer {
+                decorated
+                    .glassEffect(.regular.interactive(), in: capsule)
+            }
+        } else {
+            decorated
+        }
+    }
+}

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -675,7 +675,7 @@ struct HomeView: View {
                 HomeSegmentTotalsRowView(segment: selectedSegment, total: 0)
 
                 // Segment control in content
-                HomeGlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s) {
+                GlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s) {
                     Picker("", selection: $selectedSegment) {
                         Text("Planned Expenses").segmentedFill().tag(BudgetDetailsViewModel.Segment.planned)
                         Text("Variable Expenses").segmentedFill().tag(BudgetDetailsViewModel.Segment.variable)
@@ -687,7 +687,7 @@ struct HomeView: View {
                 }
 
                 // Filter bar (sort options)
-                HomeGlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s, alignment: .center) {
+                GlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s, alignment: .center) {
                     Picker("Sort", selection: $homeSort) {
                         Text("A–Z").segmentedFill().tag(BudgetDetailsViewModel.SortOption.titleAZ)
                         Text("$↓").segmentedFill().tag(BudgetDetailsViewModel.SortOption.amountLowHigh)
@@ -703,7 +703,7 @@ struct HomeView: View {
 
                 // Always-offer Add button when no budget exists so users can
                 // quickly create an expense for this period.
-                HomeGlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s, alignment: .center) {
+                GlassCapsuleContainer(horizontalPadding: DS.Spacing.l, verticalPadding: DS.Spacing.s, alignment: .center) {
                     Button(action: addExpenseCTAAction) {
                         Label(addExpenseCTATitle, systemImage: "plus")
                             .font(.system(size: 17, weight: .semibold, design: .rounded))
@@ -1071,48 +1071,7 @@ private struct HomeSegmentTotalsRowView: View {
     }
 }
 
-// MARK: - Empty shell helpers (glass capsule + segmented sizing)
-private struct HomeGlassCapsuleContainer<Content: View>: View {
-    @EnvironmentObject private var themeManager: ThemeManager
-    @Environment(\.responsiveLayoutContext) private var layoutContext
-    @Environment(\.platformCapabilities) private var capabilities
-
-    private let content: Content
-    private let horizontalPadding: CGFloat
-    private let verticalPadding: CGFloat
-    private let contentAlignment: Alignment
-
-    init(
-        horizontalPadding: CGFloat = DS.Spacing.l,
-        verticalPadding: CGFloat = DS.Spacing.m,
-        alignment: Alignment = .leading,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.content = content()
-        self.horizontalPadding = horizontalPadding
-        self.verticalPadding = verticalPadding
-        self.contentAlignment = alignment
-    }
-
-    var body: some View {
-        let capsule = Capsule(style: .continuous)
-        let decorated = content
-            .frame(maxWidth: .infinity, alignment: contentAlignment)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, verticalPadding)
-            .contentShape(capsule)
-
-        if #available(iOS 26.0, macOS 26.0, tvOS 18.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
-            GlassEffectContainer {
-                decorated
-                    .glassEffect(.regular.interactive(), in: capsule)
-            }
-        } else {
-            decorated
-        }
-    }
-}
-
+// MARK: - Segmented control sizing helpers
 private extension View {
     func segmentedFill() -> some View { frame(maxWidth: .infinity) }
     func equalWidthSegments() -> some View { modifier(HomeEqualWidthSegmentsModifier()) }


### PR DESCRIPTION
## Summary
- extract the reusable `GlassCapsuleContainer` into the shared components module
- update `HomeView` and `BudgetDetailsView` to rely on the shared implementation
- keep environment-driven Liquid Glass support with legacy fallback for older systems

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d942c3b5d0832c8ba0f8eea95b0422