### PR TITLE
feat: add LiquidGlassSegmentedStyle for segmented controls

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -344,12 +344,7 @@ private extension BudgetDetailsView {
                 .pickerStyle(.segmented)
                 .equalWidthSegments()
                 .frame(maxWidth: .infinity)
-#if os(macOS)
-                .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+                .liquidGlassSegmentedStyle()
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -707,8 +702,6 @@ private struct FilterBar: View {
     let onChanged: () -> Void
     let onResetDate: () -> Void
 
-    @EnvironmentObject private var themeManager: ThemeManager
-
     var body: some View {
         GlassCapsuleContainer(
             horizontalPadding: DS.Spacing.l,
@@ -734,12 +727,7 @@ private struct FilterBar: View {
             }
             .pickerStyle(.segmented)
             .equalWidthSegments()
-#if os(macOS)
-            .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+            .liquidGlassSegmentedStyle()
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/LiquidGlassSegmentedStyle.swift
+++ b/OffshoreBudgeting/Views/Components/LiquidGlassSegmentedStyle.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+// MARK: - LiquidGlassSegmentedStyle
+struct LiquidGlassSegmentedStyle: ViewModifier {
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
+
+    func body(content: Content) -> some View {
+        let accent = themeManager.selectedTheme.glassPalette.accent
+#if os(macOS)
+        if capabilities.supportsOS26Translucency {
+            if #available(macOS 26.0, *) {
+                content
+                    .background(MacSegmentedControlStyler(accentColor: accent))
+            } else {
+                content
+                    .controlSize(.large)
+                    .tint(accent)
+            }
+        } else {
+            content
+                .controlSize(.large)
+                .tint(accent)
+        }
+#else
+        content
+            .tint(accent)
+            .background(UIKitSegmentedControlStyler(accentColor: accent, supportsGlass: capabilities.supportsOS26Translucency))
+#endif
+    }
+}
+
+extension View {
+    func liquidGlassSegmentedStyle() -> some View {
+        modifier(LiquidGlassSegmentedStyle())
+    }
+}
+
+#if os(macOS)
+@available(macOS 26.0, *)
+private struct MacSegmentedControlStyler: NSViewRepresentable {
+    let accentColor: Color
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.isHidden = true
+        DispatchQueue.main.async {
+            update(view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            update(nsView)
+        }
+    }
+
+    private func update(_ hostingView: NSView) {
+        guard let control = hostingView.enclosingSegmentedControl() else { return }
+        style(control)
+    }
+
+    private func style(_ control: NSSegmentedControl) {
+        control.segmentDistribution = .fillEqually
+        control.segmentStyle = .automatic
+        control.focusRingType = .default
+        control.wantsLayer = true
+        control.layer?.cornerCurve = .continuous
+        control.layer?.cornerRadius = control.bounds.height / 2
+        control.layer?.masksToBounds = true
+        applyTint(to: control)
+    }
+
+    private func applyTint(to control: NSSegmentedControl) {
+        let tint = NSColor(accentColor)
+        control.contentTintColor = tint
+        control.layer?.backgroundColor = tint.withAlphaComponent(0.16).cgColor
+        control.layer?.borderColor = tint.withAlphaComponent(0.25).cgColor
+        control.layer?.borderWidth = 0.5
+    }
+}
+
+@available(macOS 26.0, *)
+private extension NSView {
+    func enclosingSegmentedControl() -> NSSegmentedControl? {
+        sequence(first: superview, next: { $0?.superview })
+            .compactMap { $0 as? NSSegmentedControl }
+            .first
+    }
+}
+#else
+private struct UIKitSegmentedControlStyler: UIViewRepresentable {
+    let accentColor: Color
+    let supportsGlass: Bool
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.isHidden = true
+        DispatchQueue.main.async {
+            update(view)
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        DispatchQueue.main.async {
+            update(uiView)
+        }
+    }
+
+    private func update(_ hostingView: UIView) {
+        guard let control = hostingView.enclosingSegmentedControl() else { return }
+        style(control)
+    }
+
+    private func style(_ control: UISegmentedControl) {
+        let tint = UIColor(accentColor)
+        control.selectedSegmentTintColor = supportsGlass ? tint.withAlphaComponent(0.22) : tint
+        control.backgroundColor = supportsGlass ? tint.withAlphaComponent(0.10) : nil
+        control.layer.cornerCurve = .continuous
+        control.layer.cornerRadius = control.bounds.height / 2
+        control.layer.masksToBounds = true
+        control.setTitleTextAttributes([
+            .foregroundColor: UIColor.white
+        ], for: .selected)
+        control.setTitleTextAttributes([
+            .foregroundColor: supportsGlass ? tint.withAlphaComponent(0.75) : tint
+        ], for: .normal)
+    }
+}
+
+private extension UIView {
+    func enclosingSegmentedControl() -> UISegmentedControl? {
+        sequence(first: superview, next: { $0?.superview })
+            .compactMap { $0 as? UISegmentedControl }
+            .first
+    }
+}
+#endif

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -683,7 +683,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .liquidGlassSegmentedStyle()
                 }
 
                 // Filter bar (sort options)
@@ -698,7 +698,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .liquidGlassSegmentedStyle()
                 }
 
                 // Always-offer Add button when no budget exists so users can
@@ -728,13 +728,6 @@ struct HomeView: View {
         }
         .ub_ignoreSafeArea(edges: .bottom)
         .ub_hideScrollIndicators()
-    }
-
-    private var homeSegmentedControlStyling: HomeSegmentedControlModifier {
-        HomeSegmentedControlModifier(
-            capabilities: capabilities,
-            accentColor: themeManager.selectedTheme.glassPalette.accent
-        )
     }
 
     private var headerSectionSpacing: CGFloat {
@@ -1317,25 +1310,6 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
 
     private var minimumWidth: CGFloat {
         RootHeaderActionMetrics.minimumGlassWidth(for: capabilities)
-    }
-}
-
-private struct HomeSegmentedControlModifier: ViewModifier {
-    let capabilities: PlatformCapabilities
-    let accentColor: Color
-
-    func body(content: Content) -> some View {
-#if os(macOS)
-        if capabilities.supportsOS26Translucency {
-            content
-        } else {
-            content
-                .controlSize(.large)
-                .tint(accentColor)
-        }
-#else
-        content
-#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable LiquidGlassSegmentedStyle modifier that adapts segmented controls to glass or legacy appearances
- replace the bespoke HomeView modifier and manual tinting in BudgetDetailsView with the shared style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94ea15260832c85bc354c2fd2ba80