### PR TITLE
Fix segmented control sizing for OS26

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -750,11 +750,22 @@ private extension View {
 }
 
 private struct EqualWidthSegmentsModifier: ViewModifier {
+    @Environment(\.platformCapabilities) private var capabilities
+
+    @ViewBuilder
     func body(content: Content) -> some View {
 #if os(iOS)
-        content.background(EqualWidthSegmentApplier())
+        if #available(iOS 26.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content.background(EqualWidthSegmentApplier())
+        }
 #elseif os(macOS)
-        content.background(EqualWidthSegmentApplier())
+        if #available(macOS 26.0, *), capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content.background(EqualWidthSegmentApplier())
+        }
 #else
         content
 #endif

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -1071,11 +1071,22 @@ private extension View {
 }
 
 private struct HomeEqualWidthSegmentsModifier: ViewModifier {
+    @Environment(\.platformCapabilities) private var capabilities
+
+    @ViewBuilder
     func body(content: Content) -> some View {
 #if os(iOS)
-        content.background(HomeEqualWidthSegmentApplier())
+        if #available(iOS 26.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content.background(HomeEqualWidthSegmentApplier())
+        }
 #elseif os(macOS)
-        content.background(HomeEqualWidthSegmentApplier())
+        if #available(macOS 26.0, *), capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content.background(HomeEqualWidthSegmentApplier())
+        }
 #else
         content
 #endif

--- a/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
+++ b/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
@@ -1,10 +1,14 @@
 #if os(macOS)
 import AppKit
 import ObjectiveC
+import SwiftUI
 
 enum SegmentedControlEqualWidthCoordinator {
     static func enforceEqualWidth(for segmented: NSSegmentedControl) {
         applyDistributionIfNeeded(to: segmented)
+        if #available(macOS 26.0, *), PlatformCapabilities.current.supportsOS26Translucency {
+            return
+        }
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         applyContainerConstraints(to: segmented)


### PR DESCRIPTION
## Summary
- skip cached constraint enforcement on macOS 26 now that fillEqually lays out segments reliably
- gate the UIKit/AppKit representables so OS 26 glass capsules avoid legacy equal-width hacks
- keep the fallback helpers active on earlier systems to preserve stretched legacy segments

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d957d6277c832cb3bb154afd49ddfa