### PR TITLE
fix(view): align segmented controls with capabilities

### DIFF
--- a/OffshoreBudgeting/Views/AddIncomeFormView.swift
+++ b/OffshoreBudgeting/Views/AddIncomeFormView.swift
@@ -12,6 +12,8 @@ struct AddIncomeFormView: View {
     // MARK: Environment
     @Environment(\.managedObjectContext) var viewContext   // internal so lifecycle extension can access
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
 
     // MARK: Inputs
     /// If non-nil, loads and edits an existing Income object.
@@ -124,7 +126,10 @@ struct AddIncomeFormView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()                         // no inline label column
                 .frame(maxWidth: .infinity)             // <- make the control stretch
-                .controlSize(.large)                    // (optional) nicer tap targets
+                .ubSegmentedControlStyle(
+                    capabilities: capabilities,
+                    accentColor: themeManager.selectedTheme.glassPalette.accent
+                )
                 .accessibilityIdentifier("incomeTypeSegmentedControl")
             }
             .frame(maxWidth: .infinity)                 // <- make the row stretch

--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -344,12 +344,10 @@ private extension BudgetDetailsView {
                 .pickerStyle(.segmented)
                 .equalWidthSegments()
                 .frame(maxWidth: .infinity)
-#if os(macOS)
-                .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+                .ubSegmentedControlStyle(
+                    capabilities: capabilities,
+                    accentColor: themeManager.selectedTheme.glassPalette.accent
+                )
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -708,6 +706,7 @@ private struct FilterBar: View {
     let onResetDate: () -> Void
 
     @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
 
     var body: some View {
         GlassCapsuleContainer(
@@ -734,12 +733,10 @@ private struct FilterBar: View {
             }
             .pickerStyle(.segmented)
             .equalWidthSegments()
-#if os(macOS)
-            .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+            .ubSegmentedControlStyle(
+                capabilities: capabilities,
+                accentColor: themeManager.selectedTheme.glassPalette.accent
+            )
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/UBSegmentedControlStyle.swift
+++ b/OffshoreBudgeting/Views/Components/UBSegmentedControlStyle.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+// MARK: - UBSegmentedControlStyle
+/// Applies platform-aware styling to segmented controls so macOS 15.x and earlier
+/// retain their tinted/buttons appearance while newer OS 26 releases use the
+/// system Liquid Glass treatment automatically.
+struct UBSegmentedControlStyle: ViewModifier {
+    let capabilities: PlatformCapabilities
+    let accentColor: Color
+
+    func body(content: Content) -> some View {
+#if os(macOS)
+        if capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content
+                .controlSize(.large)
+                .tint(accentColor)
+        }
+#else
+        content
+#endif
+    }
+}
+
+extension View {
+    func ubSegmentedControlStyle(capabilities: PlatformCapabilities, accentColor: Color) -> some View {
+        modifier(UBSegmentedControlStyle(capabilities: capabilities, accentColor: accentColor))
+    }
+}

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -683,7 +683,10 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .ubSegmentedControlStyle(
+                        capabilities: capabilities,
+                        accentColor: themeManager.selectedTheme.glassPalette.accent
+                    )
                 }
 
                 // Filter bar (sort options)
@@ -698,7 +701,10 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .ubSegmentedControlStyle(
+                        capabilities: capabilities,
+                        accentColor: themeManager.selectedTheme.glassPalette.accent
+                    )
                 }
 
                 // Always-offer Add button when no budget exists so users can
@@ -728,13 +734,6 @@ struct HomeView: View {
         }
         .ub_ignoreSafeArea(edges: .bottom)
         .ub_hideScrollIndicators()
-    }
-
-    private var homeSegmentedControlStyling: HomeSegmentedControlModifier {
-        HomeSegmentedControlModifier(
-            capabilities: capabilities,
-            accentColor: themeManager.selectedTheme.glassPalette.accent
-        )
     }
 
     private var headerSectionSpacing: CGFloat {
@@ -1317,25 +1316,6 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
 
     private var minimumWidth: CGFloat {
         RootHeaderActionMetrics.minimumGlassWidth(for: capabilities)
-    }
-}
-
-private struct HomeSegmentedControlModifier: ViewModifier {
-    let capabilities: PlatformCapabilities
-    let accentColor: Color
-
-    func body(content: Content) -> some View {
-#if os(macOS)
-        if capabilities.supportsOS26Translucency {
-            content
-        } else {
-            content
-                .controlSize(.large)
-                .tint(accentColor)
-        }
-#else
-        content
-#endif
     }
 }
 

--- a/OffshoreBudgeting/Views/IncomeEditorView.swift
+++ b/OffshoreBudgeting/Views/IncomeEditorView.swift
@@ -81,6 +81,10 @@ struct IncomeEditorView: View {
     let seedIncome: Income?
     let onCommit: (IncomeEditorAction) -> Bool   // return true to dismiss
     
+    // MARK: Environment
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
+
     // MARK: State
     @State private var form: IncomeEditorForm = .init()
     
@@ -123,6 +127,10 @@ struct IncomeEditorView: View {
                     Text("Actual").tag(false)
                 }
                 .pickerStyle(.segmented)
+                .ubSegmentedControlStyle(
+                    capabilities: capabilities,
+                    accentColor: themeManager.selectedTheme.glassPalette.accent
+                )
             } header: {
                 Text("Details")
             }

--- a/OffshoreBudgeting/Views/RecurrencePickerView.swift
+++ b/OffshoreBudgeting/Views/RecurrencePickerView.swift
@@ -194,6 +194,9 @@ struct RecurrencePickerView: View {
     private struct WeekdayPicker: View {
         @Binding var selected: Weekday
 
+        @EnvironmentObject private var themeManager: ThemeManager
+        @Environment(\.platformCapabilities) private var capabilities
+
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Weekday").font(.subheadline).foregroundStyle(.secondary)
@@ -203,6 +206,10 @@ struct RecurrencePickerView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .ubSegmentedControlStyle(
+                    capabilities: capabilities,
+                    accentColor: themeManager.selectedTheme.glassPalette.accent
+                )
             }
         }
 


### PR DESCRIPTION
## Summary
- add a reusable UBSegmentedControlStyle helper to centralize macOS tinting for segmented pickers
- update budget details, home, and recurrence views to honor platform capabilities when styling segmented controls
- ensure income forms and editors adopt the shared modifier so macOS 26 translucency is only applied when supported

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d95a591054832c8847b6c65999ceb0