### PR TITLE
fix: unify segmented control styling across platforms

### DIFF
--- a/OffshoreBudgeting/Views/AddIncomeFormView.swift
+++ b/OffshoreBudgeting/Views/AddIncomeFormView.swift
@@ -124,7 +124,7 @@ struct AddIncomeFormView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()                         // no inline label column
                 .frame(maxWidth: .infinity)             // <- make the control stretch
-                .controlSize(.large)                    // (optional) nicer tap targets
+                .modifier(UBSegmentedControlStyleModifier())
                 .accessibilityIdentifier("incomeTypeSegmentedControl")
             }
             .frame(maxWidth: .infinity)                 // <- make the row stretch

--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -344,12 +344,7 @@ private extension BudgetDetailsView {
                 .pickerStyle(.segmented)
                 .equalWidthSegments()
                 .frame(maxWidth: .infinity)
-#if os(macOS)
-                .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+                .modifier(UBSegmentedControlStyleModifier())
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -707,8 +702,6 @@ private struct FilterBar: View {
     let onChanged: () -> Void
     let onResetDate: () -> Void
 
-    @EnvironmentObject private var themeManager: ThemeManager
-
     var body: some View {
         GlassCapsuleContainer(
             horizontalPadding: DS.Spacing.l,
@@ -734,12 +727,7 @@ private struct FilterBar: View {
             }
             .pickerStyle(.segmented)
             .equalWidthSegments()
-#if os(macOS)
-            .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+            .modifier(UBSegmentedControlStyleModifier())
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/UBSegmentedControlStyleModifier.swift
+++ b/OffshoreBudgeting/Views/Components/UBSegmentedControlStyleModifier.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct UBSegmentedControlStyleModifier: ViewModifier {
+    @Environment(\.platformCapabilities) private var capabilities
+    @EnvironmentObject private var themeManager: ThemeManager
+
+    func body(content: Content) -> some View {
+#if os(macOS)
+        if capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content
+                .controlSize(.large)
+                .tint(themeManager.selectedTheme.primaryAccent)
+        }
+#else
+        content
+#endif
+    }
+}

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -683,7 +683,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .modifier(UBSegmentedControlStyleModifier())
                 }
 
                 // Filter bar (sort options)
@@ -698,7 +698,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .modifier(UBSegmentedControlStyleModifier())
                 }
 
                 // Always-offer Add button when no budget exists so users can
@@ -728,13 +728,6 @@ struct HomeView: View {
         }
         .ub_ignoreSafeArea(edges: .bottom)
         .ub_hideScrollIndicators()
-    }
-
-    private var homeSegmentedControlStyling: HomeSegmentedControlModifier {
-        HomeSegmentedControlModifier(
-            capabilities: capabilities,
-            accentColor: themeManager.selectedTheme.glassPalette.accent
-        )
     }
 
     private var headerSectionSpacing: CGFloat {
@@ -1317,25 +1310,6 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
 
     private var minimumWidth: CGFloat {
         RootHeaderActionMetrics.minimumGlassWidth(for: capabilities)
-    }
-}
-
-private struct HomeSegmentedControlModifier: ViewModifier {
-    let capabilities: PlatformCapabilities
-    let accentColor: Color
-
-    func body(content: Content) -> some View {
-#if os(macOS)
-        if capabilities.supportsOS26Translucency {
-            content
-        } else {
-            content
-                .controlSize(.large)
-                .tint(accentColor)
-        }
-#else
-        content
-#endif
     }
 }
 

--- a/OffshoreBudgeting/Views/IncomeEditorView.swift
+++ b/OffshoreBudgeting/Views/IncomeEditorView.swift
@@ -123,6 +123,7 @@ struct IncomeEditorView: View {
                     Text("Actual").tag(false)
                 }
                 .pickerStyle(.segmented)
+                .modifier(UBSegmentedControlStyleModifier())
             } header: {
                 Text("Details")
             }

--- a/OffshoreBudgeting/Views/RecurrencePickerView.swift
+++ b/OffshoreBudgeting/Views/RecurrencePickerView.swift
@@ -203,6 +203,7 @@ struct RecurrencePickerView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .modifier(UBSegmentedControlStyleModifier())
             }
         }
 

--- a/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
+++ b/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
@@ -1,74 +1,84 @@
 #if os(macOS)
 import AppKit
-import ObjectiveC
 
 enum SegmentedControlEqualWidthCoordinator {
     static func enforceEqualWidth(for segmented: NSSegmentedControl) {
-        applyDistributionIfNeeded(to: segmented)
-        segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        applyContainerConstraints(to: segmented)
-        segmented.invalidateIntrinsicContentSize()
+        if #available(macOS 26, *) {
+            applyModernEqualWidth(to: segmented)
+        } else {
+            applyLegacyEqualWidth(to: segmented)
+        }
     }
 
-    private static func applyDistributionIfNeeded(to segmented: NSSegmentedControl) {
+    @available(macOS 26, *)
+    private static func applyModernEqualWidth(to segmented: NSSegmentedControl) {
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
         } else {
-            let count = segmented.segmentCount
-            guard count > 0 else { return }
-            let totalWidth = segmented.bounds.width
-            guard totalWidth > 0 else { return }
-            let equalWidth = totalWidth / CGFloat(count)
-            for index in 0..<count {
-                segmented.setWidth(equalWidth, forSegment: index)
-            }
+            applyManualDistributionIfPossible(segmented)
         }
+
+        segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        segmented.invalidateIntrinsicContentSize()
     }
 
-    private static func applyContainerConstraints(to segmented: NSSegmentedControl) {
-        let cache = constraintCache(for: segmented)
-        let container = findCapsuleContainer(for: segmented)
-
-        if cache.container !== container {
-            cache.deactivateAll()
-            cache.container = container
+    private static func applyLegacyEqualWidth(to segmented: NSSegmentedControl) {
+        if #available(macOS 13.0, *) {
+            segmented.segmentDistribution = .fillEqually
+        } else {
+            applyManualDistributionIfPossible(segmented)
         }
 
-        guard let container else { return }
+        segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        guard let container = findCapsuleContainer(for: segmented) else { return }
 
         segmented.translatesAutoresizingMaskIntoConstraints = false
 
-        if let leading = cache.leading {
-            leading.isActive = true
-        } else {
-            let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
-            leading.priority = .defaultHigh
-            leading.isActive = true
-            cache.leading = leading
-        }
+        removeLegacyConstraints(attachedTo: segmented)
 
-        if let trailing = cache.trailing {
-            trailing.isActive = true
-        } else {
-            let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
-            trailing.priority = .defaultHigh
-            trailing.isActive = true
-            cache.trailing = trailing
-        }
+        let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+        leading.identifier = ConstraintIdentifier.leading
+        leading.priority = .defaultHigh
 
-        if container !== segmented.superview {
-            if let width = cache.width {
-                width.isActive = true
-            } else {
-                let width = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
-                width.priority = .defaultHigh
-                width.isActive = true
-                cache.width = width
+        let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        trailing.identifier = ConstraintIdentifier.trailing
+        trailing.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([leading, trailing])
+
+        segmented.invalidateIntrinsicContentSize()
+    }
+
+    private static func applyManualDistributionIfPossible(_ segmented: NSSegmentedControl) {
+        let count = segmented.segmentCount
+        guard count > 0 else { return }
+
+        let totalWidth = segmented.bounds.width
+        guard totalWidth > 0 else { return }
+
+        let equalWidth = totalWidth / CGFloat(count)
+        for index in 0..<count {
+            segmented.setWidth(equalWidth, forSegment: index)
+        }
+    }
+
+    private static func removeLegacyConstraints(attachedTo segmented: NSSegmentedControl) {
+        var ancestor: NSView? = segmented
+        let identifiers = Set([ConstraintIdentifier.leading, ConstraintIdentifier.trailing])
+
+        while let view = ancestor {
+            let matches = view.constraints.filter { constraint in
+                guard let id = constraint.identifier, identifiers.contains(id) else { return false }
+                let firstMatch = (constraint.firstItem as? NSSegmentedControl) === segmented
+                let secondMatch = (constraint.secondItem as? NSSegmentedControl) === segmented
+                return firstMatch || secondMatch
             }
-        } else if let width = cache.width {
-            width.isActive = false
-            cache.width = nil
+
+            NSLayoutConstraint.deactivate(matches)
+            ancestor = view.superview
         }
     }
 
@@ -93,33 +103,9 @@ enum SegmentedControlEqualWidthCoordinator {
         return className.contains("NSHostingView") || className.contains("ViewHost") || className.contains("HostingView")
     }
 
-    private static func constraintCache(for segmented: NSSegmentedControl) -> ConstraintCache {
-        if let existing = objc_getAssociatedObject(segmented, &AssociatedKeys.constraintCacheKey) as? ConstraintCache {
-            return existing
-        }
-        let storage = ConstraintCache()
-        objc_setAssociatedObject(segmented, &AssociatedKeys.constraintCacheKey, storage, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return storage
-    }
-
-    private final class ConstraintCache {
-        weak var container: NSView?
-        var leading: NSLayoutConstraint?
-        var trailing: NSLayoutConstraint?
-        var width: NSLayoutConstraint?
-
-        func deactivateAll() {
-            [leading, trailing, width].forEach { constraint in
-                constraint?.isActive = false
-            }
-            leading = nil
-            trailing = nil
-            width = nil
-        }
-    }
-
-    private enum AssociatedKeys {
-        static var constraintCacheKey: UInt8 = 0
+    private enum ConstraintIdentifier {
+        static let leading = "UBSegmentedEqualWidthLeading"
+        static let trailing = "UBSegmentedEqualWidthTrailing"
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- add a reusable segmented control style modifier that preserves Liquid Glass on macOS 26 while tinting legacy systems
- apply the shared styling to segmented controls across home, budget, income, and recurrence flows
- refresh the equal-width coordinator to rely on native distribution on macOS 26 and rebuild constraints on older releases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95f705b90832ca7145fe21b6e519e