### PR TITLE
Fix: unify segmented control styling on macOS

### DIFF
--- a/OffshoreBudgeting/Views/AddIncomeFormView.swift
+++ b/OffshoreBudgeting/Views/AddIncomeFormView.swift
@@ -124,7 +124,7 @@ struct AddIncomeFormView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()                         // no inline label column
                 .frame(maxWidth: .infinity)             // <- make the control stretch
-                .controlSize(.large)                    // (optional) nicer tap targets
+                .modifier(UBSegmentedControlStyleModifier())            // unified styling for segmented control
                 .accessibilityIdentifier("incomeTypeSegmentedControl")
             }
             .frame(maxWidth: .infinity)                 // <- make the row stretch

--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -344,12 +344,7 @@ private extension BudgetDetailsView {
                 .pickerStyle(.segmented)
                 .equalWidthSegments()
                 .frame(maxWidth: .infinity)
-#if os(macOS)
-                .controlSize(.large)
-
-                .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+                .modifier(UBSegmentedControlStyleModifier())
             }
             .padding(.horizontal, DS.Spacing.l)
             .ub_onChange(of: vm.selectedSegment) { newValue in
@@ -734,12 +729,7 @@ private struct FilterBar: View {
             }
             .pickerStyle(.segmented)
             .equalWidthSegments()
-#if os(macOS)
-            .controlSize(.large)
-
-            .tint(themeManager.selectedTheme.glassPalette.accent)
-
-#endif
+            .modifier(UBSegmentedControlStyleModifier())
             .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)

--- a/OffshoreBudgeting/Views/Components/UBSegmentedControlStyleModifier.swift
+++ b/OffshoreBudgeting/Views/Components/UBSegmentedControlStyleModifier.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+// MARK: - UBSegmentedControlStyleModifier
+struct UBSegmentedControlStyleModifier: ViewModifier {
+    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.platformCapabilities) private var capabilities
+
+    func body(content: Content) -> some View {
+#if os(macOS)
+        if capabilities.supportsOS26Translucency {
+            content
+        } else {
+            content
+                .controlSize(.large)
+                .tint(themeManager.selectedTheme.primaryAccent)
+        }
+#else
+        content
+#endif
+    }
+}
+
+extension View {
+    func ub_segmentedControlStyle() -> some View {
+        modifier(UBSegmentedControlStyleModifier())
+    }
+}
+
+extension AppTheme {
+    var primaryAccent: Color { glassPalette.accent }
+}

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -683,7 +683,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .modifier(UBSegmentedControlStyleModifier())
                 }
 
                 // Filter bar (sort options)
@@ -698,7 +698,7 @@ struct HomeView: View {
                     .pickerStyle(.segmented)
                     .equalWidthSegments()
                     .frame(maxWidth: .infinity)
-                    .modifier(homeSegmentedControlStyling)
+                    .modifier(UBSegmentedControlStyleModifier())
                 }
 
                 // Always-offer Add button when no budget exists so users can
@@ -730,12 +730,6 @@ struct HomeView: View {
         .ub_hideScrollIndicators()
     }
 
-    private var homeSegmentedControlStyling: HomeSegmentedControlModifier {
-        HomeSegmentedControlModifier(
-            capabilities: capabilities,
-            accentColor: themeManager.selectedTheme.glassPalette.accent
-        )
-    }
 
     private var headerSectionSpacing: CGFloat {
         let hasPrimarySummary = primarySummary != nil
@@ -1320,24 +1314,6 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
     }
 }
 
-private struct HomeSegmentedControlModifier: ViewModifier {
-    let capabilities: PlatformCapabilities
-    let accentColor: Color
-
-    func body(content: Content) -> some View {
-#if os(macOS)
-        if capabilities.supportsOS26Translucency {
-            content
-        } else {
-            content
-                .controlSize(.large)
-                .tint(accentColor)
-        }
-#else
-        content
-#endif
-    }
-}
 
 // MARK: - Header Action Helpers
 #if os(iOS) || os(macOS)

--- a/OffshoreBudgeting/Views/IncomeEditorView.swift
+++ b/OffshoreBudgeting/Views/IncomeEditorView.swift
@@ -123,6 +123,7 @@ struct IncomeEditorView: View {
                     Text("Actual").tag(false)
                 }
                 .pickerStyle(.segmented)
+                .modifier(UBSegmentedControlStyleModifier())
             } header: {
                 Text("Details")
             }

--- a/OffshoreBudgeting/Views/RecurrencePickerView.swift
+++ b/OffshoreBudgeting/Views/RecurrencePickerView.swift
@@ -203,6 +203,7 @@ struct RecurrencePickerView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .modifier(UBSegmentedControlStyleModifier())
             }
         }
 

--- a/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
+++ b/OffshoreBudgeting/Views/SegmentedControlEqualWidthCoordinator.swift
@@ -1,75 +1,90 @@
 #if os(macOS)
 import AppKit
-import ObjectiveC
 
 enum SegmentedControlEqualWidthCoordinator {
     static func enforceEqualWidth(for segmented: NSSegmentedControl) {
-        applyDistributionIfNeeded(to: segmented)
         segmented.setContentHuggingPriority(.defaultLow, for: .horizontal)
         segmented.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        applyContainerConstraints(to: segmented)
-        segmented.invalidateIntrinsicContentSize()
+        segmented.apportionsSegmentWidthsByContent = false
+
+        if #available(macOS 26, *) {
+            if #available(macOS 13.0, *) {
+                segmented.segmentDistribution = .fillEqually
+            }
+            segmented.invalidateIntrinsicContentSize()
+            return
+        }
+
+        enforceLegacyEqualWidth(for: segmented)
     }
 
-    private static func applyDistributionIfNeeded(to segmented: NSSegmentedControl) {
+    @available(macOS, obsoleted: 26)
+    private static func enforceLegacyEqualWidth(for segmented: NSSegmentedControl) {
         if #available(macOS 13.0, *) {
             segmented.segmentDistribution = .fillEqually
         } else {
-            let count = segmented.segmentCount
-            guard count > 0 else { return }
-            let totalWidth = segmented.bounds.width
-            guard totalWidth > 0 else { return }
-            let equalWidth = totalWidth / CGFloat(count)
-            for index in 0..<count {
-                segmented.setWidth(equalWidth, forSegment: index)
-            }
+            applyManualEqualWidthDistribution(to: segmented)
         }
-    }
-
-    private static func applyContainerConstraints(to segmented: NSSegmentedControl) {
-        let cache = constraintCache(for: segmented)
-        let container = findCapsuleContainer(for: segmented)
-
-        if cache.container !== container {
-            cache.deactivateAll()
-            cache.container = container
-        }
-
-        guard let container else { return }
 
         segmented.translatesAutoresizingMaskIntoConstraints = false
 
-        if let leading = cache.leading {
-            leading.isActive = true
-        } else {
-            let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
-            leading.priority = .defaultHigh
-            leading.isActive = true
-            cache.leading = leading
+        guard let container = findCapsuleContainer(for: segmented) else {
+            segmented.invalidateIntrinsicContentSize()
+            return
         }
 
-        if let trailing = cache.trailing {
-            trailing.isActive = true
-        } else {
-            let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
-            trailing.priority = .defaultHigh
-            trailing.isActive = true
-            cache.trailing = trailing
-        }
+        deactivateManagedConstraints(on: segmented, container: container)
+
+        var constraints: [NSLayoutConstraint] = []
+
+        let leading = segmented.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+        leading.priority = .defaultHigh
+        leading.identifier = ConstraintIdentifier.leading.rawValue
+        constraints.append(leading)
+
+        let trailing = segmented.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        trailing.priority = .defaultHigh
+        trailing.identifier = ConstraintIdentifier.trailing.rawValue
+        constraints.append(trailing)
 
         if container !== segmented.superview {
-            if let width = cache.width {
-                width.isActive = true
-            } else {
-                let width = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
-                width.priority = .defaultHigh
-                width.isActive = true
-                cache.width = width
-            }
-        } else if let width = cache.width {
-            width.isActive = false
-            cache.width = nil
+            let width = segmented.widthAnchor.constraint(equalTo: container.widthAnchor)
+            width.priority = .defaultHigh
+            width.identifier = ConstraintIdentifier.width.rawValue
+            constraints.append(width)
         }
+
+        NSLayoutConstraint.activate(constraints)
+        segmented.invalidateIntrinsicContentSize()
+    }
+
+    @available(macOS, obsoleted: 26)
+    private static func applyManualEqualWidthDistribution(to segmented: NSSegmentedControl) {
+        let count = segmented.segmentCount
+        guard count > 0 else { return }
+        let totalWidth = segmented.bounds.width
+        guard totalWidth > 0 else { return }
+        let equalWidth = totalWidth / CGFloat(count)
+        for index in 0..<count {
+            segmented.setWidth(equalWidth, forSegment: index)
+        }
+    }
+
+    private static func deactivateManagedConstraints(on segmented: NSSegmentedControl, container: NSView) {
+        let identifiers = Set(ConstraintIdentifier.allCases.map(\.rawValue))
+
+        let containerConstraints = container.constraints.filter { constraint in
+            guard let identifier = constraint.identifier, identifiers.contains(identifier) else { return false }
+            let involvesSegmented = (constraint.firstItem as? NSSegmentedControl) === segmented || (constraint.secondItem as? NSSegmentedControl) === segmented
+            return involvesSegmented
+        }
+
+        let segmentedConstraints = segmented.constraints.filter { constraint in
+            guard let identifier = constraint.identifier else { return false }
+            return identifiers.contains(identifier)
+        }
+
+        NSLayoutConstraint.deactivate(containerConstraints + segmentedConstraints)
     }
 
     private static func findCapsuleContainer(for segmented: NSSegmentedControl) -> NSView? {
@@ -93,33 +108,10 @@ enum SegmentedControlEqualWidthCoordinator {
         return className.contains("NSHostingView") || className.contains("ViewHost") || className.contains("HostingView")
     }
 
-    private static func constraintCache(for segmented: NSSegmentedControl) -> ConstraintCache {
-        if let existing = objc_getAssociatedObject(segmented, &AssociatedKeys.constraintCacheKey) as? ConstraintCache {
-            return existing
-        }
-        let storage = ConstraintCache()
-        objc_setAssociatedObject(segmented, &AssociatedKeys.constraintCacheKey, storage, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return storage
-    }
-
-    private final class ConstraintCache {
-        weak var container: NSView?
-        var leading: NSLayoutConstraint?
-        var trailing: NSLayoutConstraint?
-        var width: NSLayoutConstraint?
-
-        func deactivateAll() {
-            [leading, trailing, width].forEach { constraint in
-                constraint?.isActive = false
-            }
-            leading = nil
-            trailing = nil
-            width = nil
-        }
-    }
-
-    private enum AssociatedKeys {
-        static var constraintCacheKey: UInt8 = 0
+    private enum ConstraintIdentifier: String, CaseIterable {
+        case leading = "UBSegmentedEqualWidthLeading"
+        case trailing = "UBSegmentedEqualWidthTrailing"
+        case width = "UBSegmentedEqualWidthWidth"
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- add a reusable segmented control style modifier so macOS 26 inherits Liquid Glass while legacy releases still receive large, tinted controls
- apply the modifier across Home, Budget Details, and income-related pickers for consistent styling
- refactor SegmentedControlEqualWidthCoordinator to drop cached constraints and rely on availability-aware equal-width handling

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d95f705b90832ca7145fe21b6e519e