### PR TITLE
fix: guard segmented tint reset on macOS

### DIFF
--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -274,13 +274,21 @@ private struct MacOS26SegmentedTintDisabler: NSViewRepresentable {
 
         private func clearTint(in view: NSView) {
             if let segmented = view as? NSSegmentedControl {
-                segmented.contentTintColor = nil
+                segmented.ub_clearContentTintColorIfAvailable()
             }
 
             for child in view.subviews {
                 clearTint(in: child)
             }
         }
+    }
+}
+
+private extension NSSegmentedControl {
+    func ub_clearContentTintColorIfAvailable() {
+        let selector = NSSelectorFromString("setContentTintColor:")
+        guard responds(to: selector) else { return }
+        perform(selector, with: nil)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- guard the segmented control tint reset behind a selector availability check
- add a helper extension to perform the tint clearing dynamically when supported

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d979a8ecb8832ca7916520c3d253de