### PR TITLE
fix: rename budget filter bar type in BudgetDetailsView

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -281,7 +281,7 @@ struct BudgetDetailsView: View {
     }
 }
 
-// (removed) Inline list header — Segment Picker and FilterBar now live in the sticky header above the List
+// (removed) Inline list header — Segment Picker and BudgetDetailsFilterBar now live in the sticky header above the List
 
 // MARK: - Scrolling List Header Content
 private extension BudgetDetailsView {
@@ -352,7 +352,7 @@ private extension BudgetDetailsView {
             }
 
             // Filters (sticky header)
-            FilterBar(
+            BudgetDetailsFilterBar(
                 startDate: $vm.startDate,
                 endDate: $vm.endDate,
                 sort: $vm.sort,
@@ -693,8 +693,8 @@ private struct CategoryTotalsRow: View {
     private var chipDotSize: CGFloat { 8 }
 }
 
-// MARK: - FilterBar (unchanged API)
-private struct FilterBar: View {
+// MARK: - BudgetDetailsFilterBar (unchanged API)
+private struct BudgetDetailsFilterBar: View {
     @Binding var startDate: Date
     @Binding var endDate: Date
     @Binding var sort: BudgetDetailsViewModel.SortOption


### PR DESCRIPTION
## Summary
- rename the budget details filter bar struct to BudgetDetailsFilterBar
- update references in BudgetDetailsView to match the new type name

## Testing
- xcodebuild -project OffshoreBudgeting.xcodeproj -scheme OffshoreBudgeting -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build | xcbeautify *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9be7873f4832c905c30bd3406e3af