### PR TITLE
fix: remove macOS-only layout forks

### DIFF
--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -40,11 +40,8 @@ struct AddPlannedExpenseView: View {
     }
 
     // MARK: Layout
-    #if os(macOS)
-    private let cardRowHeight: CGFloat = 150
-    #else
+    /// Shared card picker height to align with `CardPickerRow`.
     private let cardRowHeight: CGFloat = 160
-    #endif
 
     // MARK: Init
     /// Designated initializer.

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -28,14 +28,8 @@ struct AddUnplannedExpenseView: View {
     
     // MARK: - Layout
     /// Height of the card picker row.  This matches the tile height defined in
-    /// `CardPickerRow`.  We reduce the height on macOS so the picker doesn’t
-    /// overwhelm the form.  Adjust here rather than directly inside
-    /// `CardPickerRow` for centralized control.
-    #if os(macOS)
-    private let cardRowHeight: CGFloat = 150
-    #else
+    /// `CardPickerRow` so adjustments remain centralized.
     private let cardRowHeight: CGFloat = 160
-    #endif
 
 
     // MARK: Init

--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -64,9 +64,6 @@ struct CardDetailView: View {
                     Task { await viewModel.load() }
                 }
             )
-            #if os(macOS)
-            .presentationSizing(.fitted)   // <- ensures the sheet respects the view’s ideal size
-            #endif
         }
         .ub_surfaceBackground(
             themeManager.selectedTheme,
@@ -149,8 +146,6 @@ struct CardDetailView: View {
             .navigationBarTitleDisplayMode(.inline)
         #endif
             .toolbar {
-            #if os(iOS)
-                // iOS placements
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Done") { onDone() }
                         .keyboardShortcut(.escape, modifiers: [])
@@ -178,36 +173,6 @@ struct CardDetailView: View {
                         }
                     }
                 }
-            #else
-                // macOS placements
-                ToolbarItem(placement: .automatic) {
-                    Button("Done") { onDone() }
-                        .keyboardShortcut(.escape, modifiers: [])
-                }
-                ToolbarItemGroup(placement: .automatic) {
-                    if isSearchActive {
-                        TextField("Search expenses", text: $viewModel.searchText)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 200)
-                            .focused($isSearchFieldFocused)
-                        Button("Cancel") {
-                            withAnimation {
-                                isSearchActive = false
-                                viewModel.searchText = ""
-                                isSearchFieldFocused = false
-                            }
-                        }
-                    } else {
-                        IconOnlyButton(systemName: "magnifyingglass") {
-                            withAnimation { isSearchActive = true }
-                            isSearchFieldFocused = true
-                        }
-                        IconOnlyButton(systemName: "pencil") {
-                            onEdit()
-                        }
-                    }
-                }
-            #endif
             }
     }
 

--- a/OffshoreBudgeting/Views/CardPickerItemTile.swift
+++ b/OffshoreBudgeting/Views/CardPickerItemTile.swift
@@ -23,12 +23,7 @@ struct CardPickerItemTile: View {
     /// ISO/ID-1 credit card aspect ratio (width / height).
     private let creditCardAspect: CGFloat = 85.60 / 53.98 // ≈ 1.586
     /// Visual height for the picker thumbnail. Adjust to taste.
-    /// We reduce the height slightly on macOS to avoid an oversized row.
-    #if os(macOS)
-    private let pickerHeight: CGFloat = 120
-    #else
     private let pickerHeight: CGFloat = 132
-    #endif
 
     // MARK: Body
     var body: some View {

--- a/OffshoreBudgeting/Views/CardPickerRow.swift
+++ b/OffshoreBudgeting/Views/CardPickerRow.swift
@@ -36,14 +36,9 @@ struct CardPickerRow: View {
     var includeNoneTile: Bool = false
 
     // MARK: Layout
-    // Card tile height.  We make the row slightly shorter on macOS to prevent the
-    // picker from dominating the sheet.  If you need further tuning, adjust
-    // these values here rather than inside individual views.
-    #if os(macOS)
-    private let tileHeight: CGFloat = 150
-    #else
+    // Card tile height. Adjust here rather than inside individual views so
+    // tweaks remain consistent across the app.
     private let tileHeight: CGFloat = 160
-    #endif
 
     // MARK: Body
     var body: some View {

--- a/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
+++ b/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
@@ -123,11 +123,7 @@ struct ExpenseCategoryManagerView: View {
                     }
                     .listRowBackground(themeManager.selectedTheme.secondaryBackground)
                 }
-                #if os(macOS)
-                .listStyle(.inset)
-                #else
                 .listStyle(.insetGrouped)
-                #endif
                 .applyIfAvailableScrollContentBackgroundHidden()
             }
         }

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -356,41 +356,25 @@ struct SettingsView: View {
 
     /// Balanced padding across platforms; a little more breathing room on larger screens.
     private var horizontalPadding: CGFloat {
-        #if os(macOS)
-        return 24
-        #else
         return horizontalSizeClass == .regular ? 24 : 16
-        #endif
     }
 
     private var cardStackSpacing: CGFloat {
-        #if os(iOS)
         return horizontalSizeClass == .compact ? 10 : 16
-        #else
-        return 16
-        #endif
     }
 
     private var scrollViewTopPadding: CGFloat {
-        #if os(iOS)
         return horizontalSizeClass == .compact ? DS.Spacing.m : DS.Spacing.l
-        #else
-        return DS.Spacing.l
-        #endif
     }
 
     private func extraBottomPadding(
         using proxy: RootTabPageProxy,
         tabBarGutter: RootTabPageProxy.TabBarGutter
     ) -> CGFloat {
-        #if os(iOS)
         let base = horizontalSizeClass == .compact ? 0 : DS.Spacing.l
         let tabChromeHeight: CGFloat = horizontalSizeClass == .compact ? 49 : 50
         let overflow = max(proxy.safeAreaBottomInset - tabChromeHeight, 0)
         return max(base + overflow - proxy.tabBarGutterSpacing(tabBarGutter), 0)
-        #else
-        return max(DS.Spacing.l - proxy.tabBarGutterSpacing(tabBarGutter), 0)
-        #endif
     }
 
 }

--- a/OffshoreBudgeting/Views/UBFormRow.swift
+++ b/OffshoreBudgeting/Views/UBFormRow.swift
@@ -1,31 +1,16 @@
 import SwiftUI
 
-/// Ensures form rows render in a single leading-aligned column on macOS.
+/// Ensures form rows render in a single leading-aligned column across platforms.
 /// Wrap any solitary field in `UBFormRow` to avoid the trailing "content" column
-/// that `Form` uses on macOS, which otherwise right-aligns controls.
+/// that `Form` can introduce, which otherwise right-aligns controls.
 struct UBFormRow<Content: View>: View {
     @ViewBuilder var content: Content
 
     var body: some View {
-        #if os(macOS)
-        // macOS `Form` renders two columns (label / content) and will place
-        // solitary views in the trailing "content" column which right-aligns
-        // controls.  By using `LabeledContent` with an empty trailing column we
-        // force our field into the leading slot and avoid the unwanted
-        // right‑alignment.  Other platforms don't exhibit this behaviour, so we
-        // keep the lightweight `HStack` there.
-        LabeledContent {
-            EmptyView()
-        } label: {
-            content
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        #else
         HStack(alignment: .center) {
             content
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        #endif
     }
 }


### PR DESCRIPTION
## Summary
- rely on the shared toolbar configuration in CardDetailView and drop macOS-only sheet sizing
- standardize card picker heights and category list styling on the Catalyst-friendly defaults
- remove macOS-specific padding helpers and form row handling in SettingsView and UBFormRow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d90900f0832c95dd38a6436cb66e