### PR TITLE
Fix IncomeView extension closures

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -786,8 +786,7 @@ private extension View {
             .clipShape(RoundedRectangle(cornerRadius: DS.Radius.card, style: .continuous))
             .shadow(radius: 1, y: 1)
     }
-
-
+}
 
 // MARK: - Availability Helpers
 private extension View {
@@ -827,6 +826,7 @@ private struct IncomeCalendarGlassButtonModifier: ViewModifier {
             }
             #else
             content.buttonStyle(.plain)
+            #endif
         }
         .buttonBorderShape(.roundedRectangle(radius: cornerRadius))
         .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))


### PR DESCRIPTION
## Summary
- close the income section styling extension before the availability helper extension
- add the missing `#endif` to finish the glass button modifier group while keeping shared modifiers outside the conditionals

## Testing
- Not run (requires Apple frameworks unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9e90a0cf0832c9f37fc947428ec80