### PR TITLE
Adjust macCatalyst scene declarations

### DIFF
--- a/OffshoreBudgeting/OffshoreBudgetingApp.swift
+++ b/OffshoreBudgeting/OffshoreBudgetingApp.swift
@@ -59,7 +59,9 @@ struct OffshoreBudgetingApp: App {
                 .keyboardShortcut("?", modifiers: .command)
             }
         }
+#endif
 
+#if targetEnvironment(macCatalyst)
         WindowGroup(id: catalystHelpSceneIdentifier) {
             configuredScene {
                 HelpView()


### PR DESCRIPTION
## Summary
- gate the primary scene's command group behind a macCatalyst availability check
- register the help window scene as a separate macCatalyst-only entry in the scene builder

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9ea227d68832c84878cf7613df517