### PR TITLE
Fix platform gating for iOS and Mac Catalyst

### DIFF
--- a/OffshoreBudgeting/Systems/PlatformCapabilities.swift
+++ b/OffshoreBudgeting/Systems/PlatformCapabilities.swift
@@ -6,12 +6,12 @@ import SwiftUI
 /// truth when opting into newer system behaviours.
 struct PlatformCapabilities: Equatable {
     /// Whether the current OS supports the refreshed translucent chrome
-    /// treatments Apple shipped alongside the OS 26 cycle (iOS/iPadOS/tvOS 18,
-    /// macOS 26, visionOS 2, etc.).
+    /// treatments Apple shipped alongside the OS 26 cycle (iOS/iPadOS,
+    /// macCatalyst, visionOS 2, etc.).
     let supportsOS26Translucency: Bool
 
     /// Whether the adaptive numeric keyboard layout from OS 26 is available on
-    /// this device. Only meaningful on iOS/iPadOS builds.
+    /// this device. Only meaningful on iOS builds.
     let supportsAdaptiveKeypad: Bool
 }
 
@@ -21,14 +21,18 @@ extension PlatformCapabilities {
     static var current: PlatformCapabilities {
         let supportsModernTranslucency: Bool
         // Liquid Glass is available starting with the OS 26 system releases.
-        if #available(iOS 18.0, tvOS 18.0, macOS 26.0, macCatalyst 26.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(iOS 18.0, macCatalyst 18.0, *) {
             supportsModernTranslucency = true
         } else {
             supportsModernTranslucency = false
         }
 
-        #if os(iOS) || os(tvOS)
+        #if canImport(UIKit)
+        #if targetEnvironment(macCatalyst)
+        let supportsAdaptiveKeypad = false
+        #else
         let supportsAdaptiveKeypad = supportsModernTranslucency
+        #endif
         #else
         let supportsAdaptiveKeypad = false
         #endif

--- a/OffshoreBudgeting/Systems/ResponsiveLayoutContext.swift
+++ b/OffshoreBudgeting/Systems/ResponsiveLayoutContext.swift
@@ -15,16 +15,15 @@ struct ResponsiveLayoutContext: Equatable {
         case phone
         case pad
         case mac
-        case tv
-        case watch
         case car
         case vision
         case unspecified
 
         static var current: Idiom {
-            #if os(watchOS)
-            return .watch
-            #elseif canImport(UIKit)
+            #if canImport(UIKit)
+            #if targetEnvironment(macCatalyst)
+            return .mac
+            #else
             switch UIDevice.current.userInterfaceIdiom {
             case .phone:
                 return .phone
@@ -32,20 +31,17 @@ struct ResponsiveLayoutContext: Equatable {
                 return .pad
             case .mac:
                 return .mac
-            case .tv:
-                return .tv
             case .carPlay:
                 return .car
             default:
-                if #available(iOS 17.0, tvOS 17.0, watchOS 10.0, *) {
+                if #available(iOS 17.0, *) {
                     if UIDevice.current.userInterfaceIdiom == .vision {
                         return .vision
                     }
                 }
                 return .unspecified
             }
-            #elseif os(macOS)
-            return .mac
+            #endif
             #else
             return .unspecified
             #endif
@@ -145,7 +141,7 @@ struct ResponsiveLayoutReader<Content: View>: View {
     }
 
     private func resolvedSafeAreaInsets(from proxy: GeometryProxy) -> EdgeInsets {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, macOS 12.0, *) {
             return proxy.safeAreaInsets
         } else {
             return legacySafeAreaInsets
@@ -155,7 +151,7 @@ struct ResponsiveLayoutReader<Content: View>: View {
 
 private struct LegacySafeAreaCapture: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, macOS 12.0, *) {
             content
         } else {
             content.ub_captureSafeAreaInsets()

--- a/OffshoreBudgeting/Systems/SystemTheme.swift
+++ b/OffshoreBudgeting/Systems/SystemTheme.swift
@@ -10,7 +10,7 @@ enum SystemThemeAdapter {
     enum Flavor { case liquid, classic }
 
     static var currentFlavor: Flavor {
-        if #available(iOS 18.0, tvOS 18.0, macOS 26.0, macCatalyst 26.0, watchOS 11.0, visionOS 2.0, *) {
+        if #available(iOS 18.0, macCatalyst 18.0, *) {
             return .liquid
         } else {
             return .classic


### PR DESCRIPTION
## Summary
- align platform capability detection and system theme checks with iOS and Mac Catalyst availability
- refresh compatibility helpers to remove tvOS/watchOS paths and add Catalyst-aware idiom handling
- simplify responsive layout idiom detection to rely on UIDevice and Catalyst checks

## Testing
- xcodebuild test -project 'OffshoreBudgeting.xcodeproj' -scheme OffshoreBudgeting -destination 'platform=iOS Simulator,name=iPhone 15' *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ec4e3494832c9df9132242147e21