### PR TITLE
fix(view): align catalyst availability guards

### DIFF
--- a/OffshoreBudgeting/OffshoreBudgetingApp.swift
+++ b/OffshoreBudgeting/OffshoreBudgetingApp.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-#if os(iOS)
+#if canImport(UIKit)
 import UIKit
 #endif
 
@@ -26,7 +26,7 @@ struct OffshoreBudgetingApp: App {
         CoreDataService.shared.ensureLoaded()
         UITestDataSeeder.applyIfNeeded()
         // No macOS-specific setup required at the moment.
-#if os(iOS)
+#if canImport(UIKit)
         // Reduce the chance of text truncation across the app by allowing
         // UILabel-backed Text views to shrink when space is constrained.
         let labelAppearance = UILabel.appearance()
@@ -113,12 +113,12 @@ struct OffshoreBudgetingApp: App {
 #endif
 }
 
-#if os(iOS) || os(macOS)
+#if canImport(UIKit)
 private struct ThemedToggleTint: ViewModifier {
     let color: Color
 
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             content.toggleStyle(SwitchToggleStyle(tint: color))
         } else {
             content

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -74,11 +74,11 @@ struct RootTabView: View {
 
     @ViewBuilder
     private func navigationContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             NavigationStack { content() }
         } else {
             NavigationView { content() }
-                #if os(iOS)
+                #if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
                 #endif
         }

--- a/OffshoreBudgeting/View Models/AddIncomeFormViewModel.swift
+++ b/OffshoreBudgeting/View Models/AddIncomeFormViewModel.swift
@@ -58,7 +58,7 @@ final class AddIncomeFormViewModel: ObservableObject {
     // MARK: Currency
     /// Resolve from Locale; override if you support per-budget/per-user currency.
     var currencyCode: String {
-        if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             return Locale.current.currency?.identifier ?? "USD"
         } else {
             // Fallback for earlier OS versions

--- a/OffshoreBudgeting/Views/AddCardFormView.swift
+++ b/OffshoreBudgeting/Views/AddCardFormView.swift
@@ -116,7 +116,7 @@ struct AddCardFormView: View {
                 // On macOS inside a Form, TextField("Title", text:) can render as a static label.
                 // Using the `prompt:` initializer ensures true placeholder styling.
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $cardName, prompt: Text("Apple Card"))
                             .ub_noAutoCapsAndCorrection()
                             // Align to the leading edge and expand to fill the row

--- a/OffshoreBudgeting/Views/AddIncomeFormView.swift
+++ b/OffshoreBudgeting/Views/AddIncomeFormView.swift
@@ -111,7 +111,7 @@ struct AddIncomeFormView: View {
     private var sourceSection: some View {
         UBFormSection("Source", isUppercased: true) {
             UBFormRow {
-                if #available(iOS 15.0, macOS 12.0, *) {
+                if #available(iOS 15.0, macCatalyst 15.0, *) {
                     TextField("", text: $viewModel.source, prompt: Text("Paycheck"))
                         .ub_noAutoCapsAndCorrection()
                         .multilineTextAlignment(.leading)
@@ -131,7 +131,7 @@ struct AddIncomeFormView: View {
     private var amountSection: some View {
         UBFormSection("Amount", isUppercased: true) {
             UBFormRow {
-                if #available(iOS 15.0, macOS 12.0, *) {
+                if #available(iOS 15.0, macCatalyst 15.0, *) {
                     TextField("", text: $viewModel.amountInput, prompt: Text("1000"))
                         .ub_decimalKeyboard()
                         .multilineTextAlignment(.leading)

--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -122,7 +122,7 @@ struct AddPlannedExpenseView: View {
             UBFormSection("Expense Description", isUppercased: true) {
                 // Use an empty label and a prompt for true placeholder styling on modern OSes.
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $vm.descriptionText, prompt: Text("Electric"))
                             .ub_noAutoCapsAndCorrection()
                             .multilineTextAlignment(.leading)
@@ -141,7 +141,7 @@ struct AddPlannedExpenseView: View {
             // Planned Amount
             UBFormSection("Planned Amount", isUppercased: true) {
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $vm.plannedAmountString, prompt: Text("100"))
                             .ub_decimalKeyboard()
                             .multilineTextAlignment(.leading)
@@ -160,7 +160,7 @@ struct AddPlannedExpenseView: View {
             // Actual Amount
             UBFormSection("Actual Amount", isUppercased: true) {
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $vm.actualAmountString, prompt: Text("102.50"))
                             .ub_decimalKeyboard()
                             .multilineTextAlignment(.leading)
@@ -371,7 +371,7 @@ private struct CategoryChipsRow: View {
 // A tiny compatibility wrapper to avoid directly calling presentationDetents on older OSes.
 private struct PresentationDetentsCompat: ViewModifier {
     func body(content: Content) -> some View {
-        #if os(iOS) || targetEnvironment(macCatalyst)
+        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         if #available(iOS 16.0, *) {
             content.presentationDetents([.medium])
         } else {

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -90,7 +90,7 @@ struct AddUnplannedExpenseView: View {
             // Expense Description
             UBFormSection("Expense Description", isUppercased: false) {
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $vm.descriptionText, prompt: Text("Apple Store"))
                             .ub_noAutoCapsAndCorrection()
                             .multilineTextAlignment(.leading)
@@ -109,7 +109,7 @@ struct AddUnplannedExpenseView: View {
             // Amount
             UBFormSection("Amount", isUppercased: false) {
                 UBFormRow {
-                    if #available(iOS 15.0, macOS 12.0, *) {
+                    if #available(iOS 15.0, macCatalyst 15.0, *) {
                         TextField("", text: $vm.amountString, prompt: Text("299.99"))
                             .ub_decimalKeyboard()
                             .multilineTextAlignment(.leading)

--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -355,7 +355,7 @@ private struct CombinedBudgetHeaderGrid: View {
 
     var body: some View {
         Group {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 Grid(horizontalSpacing: DS.Spacing.m, verticalSpacing: BudgetIncomeSavingsSummaryMetrics.rowSpacing) {
                     if showsIncomeGrid {
                         headerRow(title: "POTENTIAL INCOME", title2: "POTENTIAL SAVINGS")
@@ -444,7 +444,7 @@ private struct CombinedBudgetHeaderGrid: View {
         return CurrencyFormatterHelper.string(for: value)
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func headerRow(title: String, title2: String) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -453,7 +453,7 @@ private struct CombinedBudgetHeaderGrid: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func valuesRow(firstValue: Double, firstColor: Color, secondValue: Double, secondColor: Color) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -462,14 +462,14 @@ private struct CombinedBudgetHeaderGrid: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func leadingGridCell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 0) { content(); Spacer(minLength: 0) }
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func trailingGridCell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 0) { Spacer(minLength: 0); content() }
@@ -501,7 +501,7 @@ struct BudgetIncomeSavingsSummaryView: View {
 
     var body: some View {
         Group {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 Grid(horizontalSpacing: DS.Spacing.m, verticalSpacing: BudgetIncomeSavingsSummaryMetrics.rowSpacing) {
                     headerRow(title: "POTENTIAL INCOME", title2: "POTENTIAL SAVINGS")
                     valuesRow(
@@ -560,7 +560,7 @@ struct BudgetIncomeSavingsSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func headerRow(title: String, title2: String) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -574,7 +574,7 @@ struct BudgetIncomeSavingsSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func valuesRow(firstValue: Double, firstColor: Color, secondValue: Double, secondColor: Color) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -588,7 +588,7 @@ struct BudgetIncomeSavingsSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func leadingGridCell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 0) {
@@ -598,7 +598,7 @@ struct BudgetIncomeSavingsSummaryView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func trailingGridCell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 0) {
@@ -1299,7 +1299,7 @@ private extension View {
     /// Applies the plain list style and hides default backgrounds where supported; keeps your custom look.
     @ViewBuilder
     func styledList() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             self
                 .ub_listStyleLiquidAware()
 #if os(iOS)
@@ -1322,7 +1322,7 @@ private extension View {
 
     @ViewBuilder
     func ifAvailableContentMarginsZero() -> some View {
-        if #available(iOS 17.0, macOS 14.0, *) {
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
             self.contentMargins(.vertical, 0)
         } else {
             self
@@ -1335,7 +1335,7 @@ private enum CurrencyFormatterHelper {
     private static let fallbackCurrencyCode = "USD"
 
     static func string(for amount: Double) -> String {
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             return amount.formatted(.currency(code: currencyCode))
         } else {
             return legacyString(for: amount)
@@ -1343,7 +1343,7 @@ private enum CurrencyFormatterHelper {
     }
 
     private static var currencyCode: String {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             return Locale.current.currency?.identifier ?? fallbackCurrencyCode
         } else {
             return Locale.current.currencyCode ?? fallbackCurrencyCode

--- a/OffshoreBudgeting/Views/CardDetailView.swift
+++ b/OffshoreBudgeting/Views/CardDetailView.swift
@@ -118,7 +118,7 @@ struct CardDetailView: View {
     }
 
     private var currencyCode: String {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             return Locale.current.currency?.identifier ?? "USD"
         } else {
             return Locale.current.currencyCode ?? "USD"
@@ -128,7 +128,7 @@ struct CardDetailView: View {
     // MARK: navigationContainer
     @ViewBuilder
     private var navigationContainer: some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             NavigationStack {
                 navigationContent
             }

--- a/OffshoreBudgeting/Views/Components/CalendarNavigationButtonStyle.swift
+++ b/OffshoreBudgeting/Views/Components/CalendarNavigationButtonStyle.swift
@@ -36,7 +36,7 @@ struct CalendarNavigationButtonStyle: ButtonStyle {
     @ViewBuilder
     private func background(for theme: AppTheme, radius: CGFloat, isPressed: Bool) -> some View {
         let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
-        if capabilities.supportsOS26Translucency, #available(iOS 15.0, macOS 13.0, tvOS 15.0, *) {
+        if capabilities.supportsOS26Translucency, #available(iOS 15.0, macCatalyst 16.0, *) {
             shape
                 .fill(.ultraThinMaterial)
                 .overlay(

--- a/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
+++ b/OffshoreBudgeting/Views/Components/GlassCapsuleContainer.swift
@@ -34,7 +34,7 @@ struct GlassCapsuleContainer<Content: View>: View {
             .padding(.vertical, verticalPadding)
             .contentShape(capsule)
 
-        if #available(iOS 26.0, macOS 26.0, tvOS 18.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
+        if #available(iOS 26.0, macCatalyst 26.0, *), capabilities.supportsOS26Translucency {
             GlassEffectContainer {
                 decorated
                     .glassEffect(.regular.interactive(), in: capsule)

--- a/OffshoreBudgeting/Views/Components/HomeViewHelpers.swift
+++ b/OffshoreBudgeting/Views/Components/HomeViewHelpers.swift
@@ -158,11 +158,11 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
 
 
 // MARK: - Header Action Helpers
-#if os(iOS) || os(macOS)
+#if canImport(UIKit)
 struct HideMenuIndicatorIfPossible: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             content.menuIndicator(.hidden)
         } else {
             content

--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -105,7 +105,7 @@ extension View {
 #if os(iOS)
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-@available(iOS 26, tvOS 18.0, macCatalyst 26.0, *)
+@available(iOS 26, macCatalyst 26.0, *)
 private struct RootHeaderGlassCapsuleContainer<Content: View>: View {
     private let content: Content
 
@@ -130,7 +130,7 @@ private extension View {
     ) -> some View {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         if capabilities.supportsOS26Translucency {
-            if #available(iOS 26.0, tvOS 18.0, macCatalyst 26.0, *) {
+            if #available(iOS 26.0, macCatalyst 26.0, *) {
                 RootHeaderGlassCapsuleContainer { self }
             } else {
                 rootHeaderLegacyGlassDecorated(theme: theme, capabilities: capabilities)

--- a/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
+++ b/OffshoreBudgeting/Views/Components/TranslucentButtonStyle.swift
@@ -170,7 +170,7 @@ struct TranslucentButtonStyle: ButtonStyle {
         let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
 
         if capabilities.supportsOS26Translucency,
-           #available(iOS 15.0, macOS 13.0, tvOS 15.0, *) {
+           #available(iOS 15.0, macCatalyst 16.0, *) {
             shape
                 .fill(.ultraThinMaterial)
                 .overlay(shape.fill(fillColor(for: theme, isPressed: isPressed)))

--- a/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
+++ b/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
@@ -95,7 +95,7 @@ struct CustomRecurrenceEditorView: View {
     // MARK: Body
     var body: some View {
         Group {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 NavigationStack {
                     content
                         .navigationTitle("Custom Recurrence")
@@ -136,7 +136,7 @@ struct CustomRecurrenceEditorView: View {
                         }
                 }
                 // Stack style is not available on macOS; apply only on platforms that support it.
-                #if os(iOS) || os(tvOS) || os(watchOS)
+                #if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
                 #endif
             }
@@ -178,7 +178,7 @@ struct CustomRecurrenceEditorView: View {
             Section {
                 Text("Preview")
                     .font(.subheadline).foregroundStyle(.secondary)
-                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                if #available(iOS 16.0, macCatalyst 16.0, *) {
                     Text(draft.toRRULE())
                         .font(.callout).monospaced()
                         .textSelection(.enabled)

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -24,7 +24,7 @@ enum UBPresentationDetent: Equatable, Hashable {
     case large
     case fraction(Double)
 
-    #if os(iOS) || targetEnvironment(macCatalyst)
+    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     @available(iOS 16.0, *)
     var systemDetent: PresentationDetent {
         switch self {
@@ -55,7 +55,7 @@ struct EditSheetScaffold<Content: View>: View {
     @EnvironmentObject private var themeManager: ThemeManager
 
     // Selection state for detents (compat type)
-    #if os(iOS) || targetEnvironment(macCatalyst)
+    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     @State private var detentSelection: UBPresentationDetent
     #endif
 
@@ -80,7 +80,7 @@ struct EditSheetScaffold<Content: View>: View {
         self.onCancel = onCancel
         self.onSave = onSave
         self.content = content()
-        #if os(iOS) || targetEnvironment(macCatalyst)
+        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         _detentSelection = State(initialValue: initialDetent ?? detents.last ?? .medium)
         #endif
     }
@@ -129,7 +129,7 @@ struct EditSheetScaffold<Content: View>: View {
     // Navigation container: NavigationStack on iOS 16+/macOS 13+, else NavigationView
     @ViewBuilder
     private func navigationContainer<Inner: View>(@ViewBuilder content: () -> Inner) -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             NavigationStack { content() }
         } else {
             NavigationView { content() }
@@ -139,7 +139,7 @@ struct EditSheetScaffold<Content: View>: View {
     // The form body with shared styling
     @ViewBuilder
     private var formContent: some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             Form { content }
                 .scrollContentBackground(.hidden)
                 .listRowBackground(rowBackground)
@@ -177,18 +177,14 @@ struct EditSheetScaffold<Content: View>: View {
         #if canImport(UIKit)
         return Color(uiColor: .separator)
         #elseif canImport(AppKit)
-        if #available(macOS 10.14, *) {
-            return Color(nsColor: .separatorColor)
-        } else {
-            return Color.primary.opacity(0.2)
-        }
+        return Color(nsColor: .separatorColor)
         #else
         return Color.primary.opacity(0.2)
         #endif
     }
 
     // MARK: Detent selection binding (iOS only)
-    #if os(iOS) || targetEnvironment(macCatalyst)
+    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     private var detentSelectionBinding: Binding<UBPresentationDetent>? { $detentSelection }
     #else
     private var detentSelectionBinding: Binding<UBPresentationDetent>? { nil }
@@ -202,7 +198,7 @@ extension View {
         detents: [UBPresentationDetent],
         selection: Binding<UBPresentationDetent>?
     ) -> some View {
-        #if os(iOS) || targetEnvironment(macCatalyst)
+        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         if #available(iOS 16.0, *) {
             // Map compat detents to system detents
             let systemDetents = Set(detents.map { $0.systemDetent })

--- a/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
+++ b/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
@@ -219,7 +219,7 @@ private extension View {
     /// Hides list background on supported OS versions; no-ops on older targets.
     @ViewBuilder
     func applyIfAvailableScrollContentBackgroundHidden() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             scrollContentBackground(.hidden)
         } else {
             self
@@ -312,15 +312,11 @@ struct ExpenseCategoryEditorSheet: View {
         let ri = Int(round(r * 255)), gi = Int(round(g * 255)), bi = Int(round(b * 255))
         return String(format: "#%02X%02X%02X", ri, gi, bi)
         #elseif canImport(AppKit)
-        if #available(macOS 11.0, *) {
-            guard let sRGB = NSColor(color).usingColorSpace(.sRGB) else { return nil }
-            var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-            sRGB.getRed(&r, green: &g, blue: &b, alpha: &a)
-            let ri = Int(round(r * 255)), gi = Int(round(g * 255)), bi = Int(round(b * 255))
-            return String(format: "#%02X%02X%02X", ri, gi, bi)
-        } else {
-            return nil
-        }
+        guard let sRGB = NSColor(color).usingColorSpace(.sRGB) else { return nil }
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        sRGB.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let ri = Int(round(r * 255)), gi = Int(round(g * 255)), bi = Int(round(b * 255))
+        return String(format: "#%02X%02X%02X", ri, gi, bi)
         #endif
     }
 }

--- a/OffshoreBudgeting/Views/HelpView.swift
+++ b/OffshoreBudgeting/Views/HelpView.swift
@@ -8,7 +8,7 @@ struct HelpView: View {
 
     var body: some View {
         Group {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 NavigationStack {
                     helpMenu
                         .navigationTitle("Help")
@@ -18,7 +18,7 @@ struct HelpView: View {
                     helpMenu
                         .navigationBarTitle("Help")
                 }
-#if os(iOS)
+#if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
 #endif
             }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -27,7 +27,7 @@ struct HomeView: View {
     @StateObject private var vm = HomeViewModel()
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.platformCapabilities) private var capabilities
-#if os(iOS)
+#if canImport(UIKit)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 #endif
     @AppStorage(AppSettingsKeys.budgetPeriod.rawValue) private var budgetPeriodRawValue: String = BudgetPeriod.monthly.rawValue
@@ -62,7 +62,7 @@ struct HomeView: View {
     // Reset header width matching on trait changes (e.g., rotation) to avoid
     // stale measurements forcing an oversized minWidth when returning from
     // landscape → portrait. This keeps the period navigation rendering stable.
-#if os(iOS)
+#if canImport(UIKit)
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 #endif
 
@@ -136,7 +136,7 @@ struct HomeView: View {
         .alert(item: $vm.alert, content: alert(for:))
         // Clear cached/matched widths when key traits change so controls can
         // re-measure for the new size class/orientation.
-#if os(iOS)
+#if canImport(UIKit)
         .ub_onChange(of: horizontalSizeClass) { _ in resetHeaderWidthMatching() }
         .ub_onChange(of: verticalSizeClass) { _ in resetHeaderWidthMatching() }
 #endif
@@ -820,7 +820,7 @@ private struct HomeHeaderFallbackTitleView: View {
 private struct HomeIncomeSavingsZeroSummaryView: View {
     var body: some View {
         Group {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 Grid(horizontalSpacing: DS.Spacing.m, verticalSpacing: HomeIncomeSavingsMetrics.rowSpacing) {
                     headerRow("POTENTIAL INCOME", "POTENTIAL SAVINGS")
                     valuesRow(0, DS.Colors.plannedIncome, 0, DS.Colors.savingsGood)
@@ -859,7 +859,7 @@ private struct HomeIncomeSavingsZeroSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func headerRow(_ left: String, _ right: String) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -868,7 +868,7 @@ private struct HomeIncomeSavingsZeroSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func valuesRow(_ leftValue: Double, _ leftColor: Color, _ rightValue: Double, _ rightColor: Color) -> some View {
         GridRow(alignment: .lastTextBaseline) {
@@ -877,14 +877,14 @@ private struct HomeIncomeSavingsZeroSummaryView: View {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func leadingGridCell<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         HStack(spacing: 0) { content(); Spacer(minLength: 0) }
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     @ViewBuilder
     private func trailingGridCell<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         HStack(spacing: 0) { Spacer(minLength: 0); content().multilineTextAlignment(.trailing) }
@@ -908,9 +908,9 @@ private struct HomeIncomeSavingsZeroSummaryView: View {
     }
 
     private func formatCurrency(_ amount: Double) -> String {
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             let code: String
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 code = Locale.current.currency?.identifier ?? "USD"
             } else {
                 code = Locale.current.currencyCode ?? "USD"
@@ -951,9 +951,9 @@ private struct HomeSegmentTotalsRowView: View {
 
     private var totalString: String {
         // Lightweight currency formatting; mirrors the helper used elsewhere
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             let code: String
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 code = Locale.current.currency?.identifier ?? "USD"
             } else {
                 code = Locale.current.currencyCode ?? "USD"

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -191,7 +191,7 @@ struct IncomeView: View {
         if proxy.layoutContext.isLandscape,
            proxy.layoutContext.containerSize.width >= landscapeLayoutMinimumWidth {
             landscapeLayout(using: proxy, availableHeight: availableHeight)
-        } else if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        } else if #available(iOS 16.0, macCatalyst 16.0, *) {
             ViewThatFits(in: .vertical) {
                 nonScrollingLayout(using: proxy, availableHeight: availableHeight)
                 scrollingLayout(using: proxy)
@@ -360,7 +360,7 @@ struct IncomeView: View {
         let end = cal.date(byAdding: .year, value: 5, to: today)!
         VStack(spacing: CalendarSectionMetrics.headerSpacing) {
             HStack(spacing: DS.Spacing.s) {
-                if #available(iOS 18.0, tvOS 18.0, macCatalyst 18.0, *), capabilities.supportsOS26Translucency {
+                if #available(iOS 18.0, macCatalyst 18.0, *), capabilities.supportsOS26Translucency {
                     Button("<<") { goToPreviousMonth() }
                         .accessibilityLabel("Previous Month")
                         .incomeCalendarGlassButtonStyle(role: .icon)
@@ -793,7 +793,7 @@ private extension View {
     /// Hides list background on supported OS versions; no-ops on older targets.
     @ViewBuilder
     func applyIfAvailableScrollContentBackgroundHidden() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             scrollContentBackground(.hidden)
         } else {
             self
@@ -816,7 +816,7 @@ private struct IncomeCalendarGlassButtonModifier: ViewModifier {
         Group {
             #if swift(>=6.0)
             if capabilities.supportsOS26Translucency {
-                if #available(iOS 18.0, macOS 26.0, tvOS 18.0, visionOS 2.0, macCatalyst 26.0, *) {
+                if #available(iOS 18.0, macCatalyst 26.0, visionOS 2.0, *) {
                     content.buttonStyle(.glass)
                 } else {
                     content.buttonStyle(.plain)

--- a/OffshoreBudgeting/Views/OnboardingView.swift
+++ b/OffshoreBudgeting/Views/OnboardingView.swift
@@ -348,21 +348,21 @@ private struct CardsStep: View {
     // MARK: - Navigation container compatibility
     @ViewBuilder
     private func navigationContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             navigationStack(content: content)
         } else {
             navigationView(content: content)
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     private func navigationStack<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationStack { content() }
     }
 
     private func navigationView<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationView { content() }
-        #if os(iOS)
+        #if canImport(UIKit)
             .navigationViewStyle(.stack)
         #endif
     }
@@ -641,21 +641,21 @@ private struct CategoriesStep: View {
     // MARK: - Navigation container compatibility
     @ViewBuilder
     private func navigationContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             navigationStack(content: content)
         } else {
             navigationView(content: content)
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+    @available(iOS 16.0, macCatalyst 16.0, *)
     private func navigationStack<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationStack { content() }
     }
 
     private func navigationView<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationView { content() }
-        #if os(iOS)
+        #if canImport(UIKit)
             .navigationViewStyle(.stack)
         #endif
     }
@@ -787,7 +787,7 @@ private struct OnboardingSecondaryButtonStyle: ButtonStyle {
 
     @ViewBuilder
     private func background(isPressed: Bool, radius: CGFloat) -> some View {
-        if capabilities.supportsOS26Translucency, #available(iOS 15.0, macOS 13.0, tvOS 15.0, *) {
+        if capabilities.supportsOS26Translucency, #available(iOS 15.0, macCatalyst 16.0, *) {
             RoundedRectangle(cornerRadius: radius, style: .continuous)
                 .fill(tint.opacity(isPressed ? 0.2 : 0.14))
                 .background(
@@ -874,7 +874,7 @@ private struct OnboardingGlassBackground: View {
 
     var body: some View {
         Group {
-            if capabilities.supportsOS26Translucency, #available(iOS 15.0, macOS 13.0, tvOS 15.0, *) {
+            if capabilities.supportsOS26Translucency, #available(iOS 15.0, macCatalyst 16.0, *) {
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .fill(tint.opacity(0.16))
                     .background(
@@ -934,7 +934,7 @@ private struct CloudOptionToggle: View {
             Toggle("", isOn: $isOn)
                 .labelsHidden()
                 .disabled(!isEnabled)
-#if os(iOS) || os(macOS)
+#if canImport(UIKit)
                 .controlSize(.large)
 #endif
         }

--- a/OffshoreBudgeting/Views/PresetBudgetAssignmentSheet.swift
+++ b/OffshoreBudgeting/Views/PresetBudgetAssignmentSheet.swift
@@ -94,7 +94,7 @@ struct PresetBudgetAssignmentSheet: View {
     // MARK: - Navigation container (iOS 16+/macOS 13+ NavigationStack; older NavigationView)
     @ViewBuilder
     private func navigationContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             NavigationStack { content() }
         } else {
             NavigationView { content() }

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -363,7 +363,7 @@ private extension View {
     /// Hides list background on supported OS versions; no-ops on older targets.
     @ViewBuilder
     func applyIfAvailableScrollContentBackgroundHidden() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             scrollContentBackground(.hidden)
         } else {
             self

--- a/OffshoreBudgeting/Views/UBEmptyState.swift
+++ b/OffshoreBudgeting/Views/UBEmptyState.swift
@@ -106,7 +106,7 @@ struct UBEmptyState: View {
     }
 
     private var resolvedVerticalPadding: CGFloat {
-        #if os(iOS)
+        #if canImport(UIKit)
         return verticalSizeClass == .compact ? DS.Spacing.s : DS.Spacing.m
         #else
         return DS.Spacing.m
@@ -146,7 +146,7 @@ struct UBEmptyState: View {
             .labelStyle(.titleAndIcon)
     }
 
-#if os(iOS)
+#if canImport(UIKit)
     @ViewBuilder
     private func glassPrimaryButton(
         title: String,
@@ -193,14 +193,14 @@ struct UBEmptyState: View {
         glassTint: Color,
         action: @escaping () -> Void
     ) -> some View {
-        if capabilities.supportsOS26Translucency, #available(macOS 26.0, tvOS 18.0, *) {
+        if capabilities.supportsOS26Translucency, #available(macCatalyst 26.0, *) {
             glassStyledPrimaryButton(title: title, glassTint: glassTint, action: action)
         } else {
             legacyPrimaryButton(title: title, action: action)
         }
     }
 
-    @available(macOS 26.0, tvOS 18.0, *)
+    @available(macCatalyst 26.0, *)
     @ViewBuilder
     private func glassStyledPrimaryButton(
         title: String,
@@ -226,7 +226,7 @@ struct UBEmptyState: View {
     }
 #endif
 
-    #if os(iOS)
+    #if canImport(UIKit)
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     #endif
     private var primaryButtonTint: Color {


### PR DESCRIPTION
## Summary
- replace os(iOS)/macOS compilation checks with canImport(UIKit) gating for the app entry point and onboarding flow
- update navigation stacks, currency formatting, and form prompts to test macCatalyst availability instead of macOS/tvOS across core views
- refresh shared SwiftUI components to rely on UIKit/macCatalyst logic and drop unused macOS/tvOS availability branches

## Testing
- xcodebuild -version *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ee2adfcc832ca7a4c129105c568b