### PR TITLE
chore: remove legacy mac platform guards

### DIFF
--- a/OffshoreBudgeting/OffshoreBudgetingApp.swift
+++ b/OffshoreBudgeting/OffshoreBudgetingApp.swift
@@ -6,9 +6,7 @@
 //
 
 import SwiftUI
-#if canImport(UIKit)
 import UIKit
-#endif
 
 @main
 struct OffshoreBudgetingApp: App {
@@ -26,14 +24,12 @@ struct OffshoreBudgetingApp: App {
         CoreDataService.shared.ensureLoaded()
         UITestDataSeeder.applyIfNeeded()
         // No macOS-specific setup required at the moment.
-#if canImport(UIKit)
         // Reduce the chance of text truncation across the app by allowing
         // UILabel-backed Text views to shrink when space is constrained.
         let labelAppearance = UILabel.appearance()
         labelAppearance.adjustsFontSizeToFitWidth = true
         labelAppearance.minimumScaleFactor = 0.5
         labelAppearance.lineBreakMode = .byClipping
-#endif
     }
 
     var body: some Scene {
@@ -113,7 +109,6 @@ struct OffshoreBudgetingApp: App {
 #endif
 }
 
-#if canImport(UIKit)
 private struct ThemedToggleTint: ViewModifier {
     let color: Color
 
@@ -125,10 +120,3 @@ private struct ThemedToggleTint: ViewModifier {
         }
     }
 }
-#else
-private struct ThemedToggleTint: ViewModifier {
-    let color: Color
-
-    func body(content: Content) -> some View { content }
-}
-#endif

--- a/OffshoreBudgeting/Resources/UnifiedSwipeActions.swift
+++ b/OffshoreBudgeting/Resources/UnifiedSwipeActions.swift
@@ -7,9 +7,7 @@
 //
 
 import SwiftUI
-#if canImport(UIKit)
 import UIKit
-#endif
 
 // MARK: - UnifiedSwipeConfig
 public struct UnifiedSwipeConfig {
@@ -56,16 +54,11 @@ public struct UnifiedSwipeConfig {
 
     // MARK: Platform Defaults
     public static var defaultDeleteTint: Color {
-        #if canImport(UIKit)
-        return Color(UIColor.systemRed)
-        #else
-        return .red
-        #endif
+        Color(UIColor.systemRed)
     }
 
     public static var defaultEditTint: Color {
-        #if canImport(UIKit)
-        return Color(UIColor { trait in
+        Color(UIColor { trait in
             switch trait.userInterfaceStyle {
             case .dark:
                 return UIColor(white: 0.28, alpha: 1.0)
@@ -73,9 +66,6 @@ public struct UnifiedSwipeConfig {
                 return UIColor(white: 0.92, alpha: 1.0)
             }
         })
-        #else
-        return Color.gray.opacity(0.35)
-        #endif
     }
 }
 
@@ -98,7 +88,7 @@ public struct UnifiedSwipeCustomAction: Identifiable {
         action: @escaping () -> Void
     ) {
         self.title = title
-               self.systemImageName = systemImageName
+        self.systemImageName = systemImageName
         self.tint = tint
         self.role = role
         self.accessibilityID = accessibilityID
@@ -141,7 +131,6 @@ private struct UnifiedSwipeActionsModifier: ViewModifier {
             .accessibilityIdentifierIfAvailable(config.deleteAccessibilityID)
         }
 
-        #if canImport(UIKit)
         if #available(iOS 15.0, macCatalyst 15.0, *) {
             base.swipeActions(edge: .trailing, allowsFullSwipe: config.allowsFullSwipeToDelete) {
                 deleteButton()
@@ -151,9 +140,6 @@ private struct UnifiedSwipeActionsModifier: ViewModifier {
         } else {
             base
         }
-        #else
-        base
-        #endif
     }
 
     // MARK: Buttons
@@ -216,7 +202,7 @@ private struct UnifiedSwipeActionsModifier: ViewModifier {
         let title: String
         let systemImageName: String
         let iconOverride: Color?
-               let textOverride: Color?
+        let textOverride: Color?
 
         var body: some View {
             Label {
@@ -238,12 +224,10 @@ private struct UnifiedSwipeActionsModifier: ViewModifier {
 
     // MARK: - Helpers
     private func triggerDelete() {
-        #if canImport(UIKit)
         if config.playHapticOnDelete {
             let generator = UIImpactFeedbackGenerator(style: .light)
             generator.impactOccurred()
         }
-        #endif
         onDelete()
     }
 
@@ -271,11 +255,7 @@ private extension View {
     @ViewBuilder
     func accessibilityIdentifierIfAvailable(_ identifier: String?) -> some View {
         if let identifier {
-            #if canImport(UIKit)
             self.accessibilityIdentifier(identifier)
-            #else
-            self
-            #endif
         } else {
             self
         }
@@ -299,18 +279,14 @@ private extension View {
 // MARK: - Color Helpers
 private extension Color {
     var ub_contrastingForegroundColor: Color {
-        #if canImport(UIKit)
         let uiColor = UIColor(self)
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         guard uiColor.getRed(&r, green: &g, blue: &b, alpha: &a) else { return .white }
         return Color.contrastingColor(red: r, green: g, blue: b)
-        #else
-        return .white
-        #endif
     }
 
     static func contrastingColor(red: CGFloat, green: CGFloat, blue: CGFloat) -> Color {
-        let brightness = 0.299*red + 0.587*green + 0.114*blue
+        let brightness = 0.299 * red + 0.587 * green + 0.114 * blue
         return brightness < 0.6 ? .white : .black
     }
 }

--- a/OffshoreBudgeting/Systems/AppTheme.swift
+++ b/OffshoreBudgeting/Systems/AppTheme.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import Combine
 import Foundation
-#if canImport(UIKit)
 import UIKit
-#endif
 
 // MARK: - Cloud Sync Infrastructure
 // This file's cloud-sync components require the iCloud Key-Value storage
@@ -105,7 +103,6 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     /// UI-facing list of selectable themes.
     static var selectableCases: [AppTheme] { allCases }
 
-    #if canImport(UIKit)
     /// Dynamic neutral accent that mirrors the system's black text in light mode
     /// and white text in dark mode without relying on an asset catalog color.
     private static var systemNeutralAccent: Color {
@@ -115,7 +112,6 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
                 : UIColor(white: 0.0, alpha: 1.0)
         })
     }
-    #endif
 
     /// Human readable name shown in pickers.
     var displayName: String {
@@ -138,11 +134,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var accent: Color {
         switch self {
         case .system:
-            #if canImport(UIKit)
             return AppTheme.systemNeutralAccent
-            #else
-            return Color.primary
-            #endif
         case .classic: return .blue
         case .midnight: return .purple
         case .forest: return .green
@@ -166,11 +158,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var tint: Color? {
         switch self {
         case .system:
-            #if canImport(UIKit)
             return AppTheme.systemNeutralAccent
-            #else
-            return Color.primary
-            #endif
         default:
             return accent
         }
@@ -186,11 +174,7 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var toggleTint: Color {
         switch self {
         case .system:
-#if canImport(UIKit)
             return Color(UIColor.systemGreen)
-#else
-            return Color.green
-#endif
         default:
             return resolvedTint
         }
@@ -198,31 +182,19 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
 
     /// Secondary accent color derived from the primary accent.
     var secondaryAccent: Color {
-        #if canImport(UIKit)
         let uiColor = UIColor(accent)
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         uiColor.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
         return Color(hue: Double(h), saturation: Double(s * 0.5), brightness: Double(min(b * 1.2, 1.0)))
-        #else
-        return accent
-        #endif
     }
 
     /// Primary background color for views.
     var background: Color {
         switch self {
         case .system:
-            #if canImport(UIKit)
             return Color(UIColor.systemBackground)
-            #else
-            return Color.white
-            #endif
         case .classic:
-            #if canImport(UIKit)
             return Color(UIColor.systemGroupedBackground)
-            #else
-            return Color.white
-            #endif
         case .midnight:
             return Color.black
         case .forest:
@@ -248,17 +220,9 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var secondaryBackground: Color {
         switch self {
         case .system:
-            #if canImport(UIKit)
             return Color(UIColor.secondarySystemBackground)
-            #else
-            return Color.white.opacity(0.9)
-            #endif
         case .classic:
-            #if canImport(UIKit)
             return Color(UIColor.secondarySystemGroupedBackground)
-            #else
-            return Color.gray.opacity(0.1)
-            #endif
         case .midnight:
             return Color(red: 0.15, green: 0.15, blue: 0.18)
         case .forest:
@@ -284,17 +248,9 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     var tertiaryBackground: Color {
         switch self {
         case .system:
-            #if canImport(UIKit)
             return Color(UIColor.tertiarySystemBackground)
-            #else
-            return Color.white.opacity(0.85)
-            #endif
         case .classic:
-            #if canImport(UIKit)
             return Color(UIColor.tertiarySystemGroupedBackground)
-            #else
-            return Color.gray.opacity(0.15)
-            #endif
         case .midnight:
             return Color(red: 0.12, green: 0.12, blue: 0.15)
         case .forest:
@@ -359,7 +315,6 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
 
     /// Theme-aware base color used when rendering OS 26 translucent surfaces.
     var glassBaseColor: Color {
-        #if canImport(UIKit)
         let accentWash = AppThemeColorUtilities.adjust(
             resolvedTint,
             saturationMultiplier: 0.45,
@@ -386,14 +341,10 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         default:
             return AppThemeColorUtilities.mix(background, accentWash, amount: blendAmount)
         }
-        #else
-        return background
-        #endif
     }
 
     /// Palette used when rendering OS 26 translucent surfaces.
     var glassPalette: GlassConfiguration.Palette {
-        #if canImport(UIKit)
         let accent: Color
         let shadow: Color
         let specular: Color
@@ -471,14 +422,10 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
         }
 
         return GlassConfiguration.Palette(accent: accent, shadow: shadow, specular: specular, rim: rim)
-        #else
-        return GlassConfiguration.Palette(accent: resolvedTint, shadow: .gray, specular: .white, rim: .white)
-        #endif
     }
 
     /// Color palette used to render tab bar content across platforms.
     var tabBarPalette: TabBarPalette {
-        #if canImport(UIKit)
         let brightness = AppThemeColorUtilities.hsba(from: glassBaseColor)?.brightness
             ?? AppThemeColorUtilities.hsba(from: background)?.brightness
             ?? 0.65
@@ -517,15 +464,6 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
             badgeBackground: badgeBackground,
             badgeForeground: badgeForeground
         )
-        #else
-        return TabBarPalette(
-            active: resolvedTint,
-            inactive: Color.primary.opacity(0.75),
-            disabled: Color.primary.opacity(0.34),
-            badgeBackground: resolvedTint,
-            badgeForeground: Color.white
-        )
-        #endif
     }
 
     /// Indicates whether the theme opts into the custom glass materials used
@@ -541,7 +479,6 @@ enum AppTheme: String, CaseIterable, Identifiable, Codable {
     }
 }
 
-#if canImport(UIKit)
 extension AppTheme {
     /// iOS/iPadOS System glass tuned brighter and more neutral.
     static func systemGlassConfiguration(resolvedTint: Color) -> GlassConfiguration {
@@ -662,7 +599,6 @@ extension AppTheme {
         )
     }
 }
-#endif
 
 // MARK: - AppTheme.GlassConfiguration
 
@@ -692,7 +628,7 @@ extension AppTheme {
                 case ultraThick
 
                 #if os(iOS) || os(tvOS)
-                @available(iOS 15.0, macOS 13.0, tvOS 15.0, *)
+                @available(iOS 15.0, macCatalyst 15.0, tvOS 15.0, *)
                 var shapeStyle: AnyShapeStyle {
                     switch self {
                     case .ultraThin: return AnyShapeStyle(.ultraThinMaterial)
@@ -704,7 +640,6 @@ extension AppTheme {
                 }
                 #endif
 
-                #if canImport(UIKit)
                 var uiBlurEffectStyle: UIBlurEffect.Style {
                     switch self {
                     case .ultraThin: return .systemUltraThinMaterial
@@ -714,7 +649,6 @@ extension AppTheme {
                     case .ultraThick: return .systemChromeMaterial
                     }
                 }
-                #endif
             }
 
             var highlightColor: Color
@@ -863,7 +797,6 @@ fileprivate enum AppThemeColorUtilities {
     }
 
     static func rgba(from color: Color) -> RGBA? {
-        #if canImport(UIKit)
         let platformColor = UIColor(color)
         var red: CGFloat = 0
         var green: CGFloat = 0
@@ -871,13 +804,9 @@ fileprivate enum AppThemeColorUtilities {
         var alpha: CGFloat = 0
         guard platformColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return nil }
         return RGBA(red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
-        #else
-        return nil
-        #endif
     }
 
     static func hsba(from color: Color) -> HSBA? {
-        #if canImport(UIKit)
         let platformColor = UIColor(color)
         var hue: CGFloat = 0
         var saturation: CGFloat = 0
@@ -885,9 +814,6 @@ fileprivate enum AppThemeColorUtilities {
         var alpha: CGFloat = 0
         guard platformColor.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) else { return nil }
         return HSBA(hue: Double(hue), saturation: Double(saturation), brightness: Double(brightness), alpha: Double(alpha))
-        #else
-        return nil
-        #endif
     }
 
     static func color(from rgba: RGBA) -> Color {
@@ -1046,7 +972,6 @@ final class ThemeManager: ObservableObject {
     }
 
     private func applyAppearance() {
-        #if canImport(UIKit)
         let style: UIUserInterfaceStyle
         if let scheme = selectedTheme.colorScheme {
             style = scheme == .dark ? .dark : .light
@@ -1057,7 +982,6 @@ final class ThemeManager: ObservableObject {
             .compactMap { $0 as? UIWindowScene }
             .flatMap { $0.windows }
             .forEach { $0.overrideUserInterfaceStyle = style }
-        #endif
     }
 
     private static func resolveTheme(from raw: String?) -> AppTheme {

--- a/OffshoreBudgeting/Systems/CardTheme.swift
+++ b/OffshoreBudgeting/Systems/CardTheme.swift
@@ -9,26 +9,17 @@ import SwiftUI
 
 // MARK: - Platform Color Bridge
 // Uses UIColor on iOS/Catalyst and NSColor on macOS for Canvas CG drawing.
-#if canImport(UIKit)
 import UIKit
-#elseif canImport(AppKit)
-import AppKit
-#endif
 
 // MARK: - Helper: labelCGColor(_:)
 // Returns a platform-appropriate label color as CGColor with the given alpha.
 // - iOS/Catalyst: UIColor.label
 // - macOS:        NSColor.labelColor
 private func labelCGColor(_ alpha: CGFloat) -> CGColor {
-    #if canImport(UIKit)
     return UIColor.label.withAlphaComponent(alpha).cgColor
-    #else
-    return NSColor.labelColor.withAlphaComponent(alpha).cgColor
-    #endif
 }
 
 private func rgbaComponents(from color: Color) -> (Double, Double, Double, Double)? {
-    #if canImport(UIKit)
     let platformColor = UIColor(color)
     var red: CGFloat = 0
     var green: CGFloat = 0
@@ -36,21 +27,6 @@ private func rgbaComponents(from color: Color) -> (Double, Double, Double, Doubl
     var alpha: CGFloat = 0
     guard platformColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return nil }
     return (Double(red), Double(green), Double(blue), Double(alpha))
-    #elseif canImport(AppKit)
-    let platformColor = NSColor(color)
-    let converted = platformColor.usingColorSpace(.deviceRGB)
-        ?? platformColor.usingColorSpace(.sRGB)
-        ?? platformColor.usingColorSpace(.genericRGB)
-    guard let converted else { return nil }
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
-    converted.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-    return (Double(red), Double(green), Double(blue), Double(alpha))
-    #else
-    return nil
-    #endif
 }
 
 // MARK: - CardTheme

--- a/OffshoreBudgeting/Systems/Compatibility.swift
+++ b/OffshoreBudgeting/Systems/Compatibility.swift
@@ -7,9 +7,7 @@
 //
 
 import SwiftUI
-#if canImport(UIKit)
 import UIKit
-#endif
 
 // MARK: - Glass Background Policy
 
@@ -88,18 +86,8 @@ extension View {
     /// Disables auto-capitalization and autocorrection where supported (iOS/iPadOS).
     /// On other platforms this is a no-op, allowing a single code path.
     func ub_noAutoCapsAndCorrection() -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         return self
-        #else
-        if #available(iOS 15.0, *) {
-            return self
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled(true)
-        } else {
-            return self.disableAutocorrection(true)
-        }
-        #endif
         #else
         return self
         #endif
@@ -109,16 +97,8 @@ extension View {
     /// Sets the navigation/toolbar title to inline across platforms.
     /// Uses the best available API per OS version and is a no-op if unavailable.
     func ub_toolbarTitleInline() -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         return self
-        #else
-        if #available(iOS 17.0, *) {
-            return self.toolbarTitleDisplayMode(.inline)
-        } else {
-            return self.navigationBarTitleDisplayMode(.inline)
-        }
-        #endif
         #else
         return self
         #endif
@@ -130,18 +110,8 @@ extension View {
     /// that do not expose the API.
     @ViewBuilder
     func ub_toolbarTitleLarge() -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         self
-        #else
-        if #available(iOS 17.0, *) {
-            self
-                .toolbarTitleDisplayMode(.large)
-                .navigationBarTitleDisplayMode(.large)
-        } else {
-            self.navigationBarTitleDisplayMode(.large)
-        }
-        #endif
         #else
         self
         #endif
@@ -171,12 +141,8 @@ extension View {
     // MARK: ub_compactDatePickerStyle()
     /// Applies `.compact` date picker style where available (iPhone/iPad), no-op elsewhere.
     func ub_compactDatePickerStyle() -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         return self
-        #else
-        return self.datePickerStyle(.compact)
-        #endif
         #else
         return self
         #endif
@@ -290,7 +256,7 @@ extension View {
     /// don’t support it, this is a no-op so the view still compiles.  Use
     /// this helper instead of sprinkling `#if` checks throughout your views.
     func ub_formStyleGrouped() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             return self.formStyle(.grouped)
         } else {
             return self
@@ -321,7 +287,7 @@ extension View {
     /// versions it falls back to the legacy API.  Use this to avoid
     /// repetitive availability checks.
     func ub_hideScrollIndicators() -> some View {
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
             return self.scrollIndicators(.hidden)
         } else {
             return self
@@ -351,7 +317,7 @@ private struct UBListStyleLiquidAwareModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if UBGlassBackgroundPolicy.shouldUseSystemChrome(capabilities: capabilities) {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 content
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
@@ -364,7 +330,7 @@ private struct UBListStyleLiquidAwareModifier: ViewModifier {
                     .ub_applyListRowSeparators()
             }
         } else {
-            if #available(iOS 16.0, macOS 13.0, *) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
                 content
                     .listStyle(.insetGrouped)
                     .scrollContentBackground(.hidden)
@@ -383,7 +349,7 @@ private struct UBListStyleLiquidAwareModifier: ViewModifier {
 private extension View {
     @ViewBuilder
     func ub_applyListRowSeparators() -> some View {
-        if #available(iOS 15.0, macCatalyst 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             self
                 .listRowSeparator(.visible)
                 .listRowSeparatorTint(UBListStyleSeparators.separatorColor)
@@ -421,11 +387,7 @@ private extension View {
 
 private enum UBListStyleSeparators {
     static var separatorColor: Color {
-        #if canImport(UIKit)
         return Color(uiColor: .separator)
-        #else
-        return .secondary
-        #endif
     }
 }
 
@@ -447,16 +409,8 @@ private struct UBRootTabNavigationTitleModifier: ViewModifier {
     let title: String
 
     func body(content: Content) -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         return content.navigationTitle(title)
-        #else
-        if #available(iOS 16.0, *) {
-            return content.toolbar(.hidden, for: .navigationBar)
-        } else {
-            return content.navigationBarHidden(true)
-        }
-        #endif
         #else
         return content.navigationTitle(title)
         #endif
@@ -473,7 +427,7 @@ private struct UBOnChangeWithoutValueModifier<Value: Equatable>: ViewModifier {
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 17.0, macCatalyst 17.0, macOS 14.0, *) {
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
             content.onChange(of: value, initial: initial, action)
         } else {
             content.task(id: value) {
@@ -500,7 +454,7 @@ private struct UBOnChangeWithValueModifier<Value: Equatable>: ViewModifier {
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(iOS 17.0, macCatalyst 17.0, macOS 14.0, *) {
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
             content.onChange(of: value, initial: initial) { _, newValue in
                 action(newValue)
             }
@@ -526,22 +480,8 @@ private struct UBDecimalKeyboardModifier: ViewModifier {
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         content
-        #else
-        if platformCapabilities.supportsAdaptiveKeypad {
-            if #available(iOS 18.0, *) {
-                content
-                    .keyboardType(.decimalPad)
-                    .submitLabel(.done)
-            } else {
-                content.keyboardType(.decimalPad)
-            }
-        } else {
-            content.keyboardType(.decimalPad)
-        }
-        #endif
         #else
         content
         #endif
@@ -703,13 +643,9 @@ private struct UBGlassBackgroundView: View {
     @ViewBuilder
     private var baseLayer: some View {
         if capabilities.supportsOS26Translucency {
-            if #available(iOS 15.0, macCatalyst 15.0, macOS 13.0, *) {
-                #if canImport(UIKit)
+            if #available(iOS 15.0, macCatalyst 15.0, *) {
                 decoratedGlass
                     .background(configuration.glass.material.shapeStyle)
-                #else
-                decoratedGlass
-                #endif
             } else {
                 decoratedGlass
             }
@@ -846,21 +782,11 @@ private extension Edge.Set {
 extension View {
     @ViewBuilder
     func ub_ignoreSafeArea(edges: Edge.Set) -> some View {
-        #if canImport(UIKit)
         if #available(iOS 17.0, macCatalyst 17.0, *) {
             self.ignoresSafeArea(.container, edges: edges)
         } else {
             self.edgesIgnoringSafeArea(edges)
         }
-        #elseif os(macOS)
-        if #available(macOS 14.0, *) {
-            self.ignoresSafeArea(.container, edges: edges)
-        } else {
-            self.edgesIgnoringSafeArea(edges)
-        }
-        #else
-        self
-        #endif
     }
 }
 
@@ -870,20 +796,12 @@ extension View {
 enum UBColor {
     /// Top neutral for card backgrounds.
     static var cardNeutralTop: Color {
-        #if canImport(UIKit)
         return Color(UIColor.secondarySystemBackground) // iOS
-        #else
-        return Color.gray.opacity(0.16)
-        #endif
     }
 
     /// Bottom neutral for card backgrounds.
     static var cardNeutralBottom: Color {
-        #if canImport(UIKit)
         return Color(UIColor.tertiarySystemBackground) // iOS
-        #else
-        return Color.gray.opacity(0.22)
-        #endif
     }
 }
 
@@ -893,11 +811,7 @@ enum UBColor {
 enum UBTypography {
     /// Static title color for card text (legible dark tone on all platforms).
     static var cardTitleStatic: Color {
-        #if canImport(UIKit)
         return Color(UIColor.label).opacity(0.92)              // iOS: dark, dynamic
-        #else
-        return Color.black.opacity(0.9)
-        #endif
     }
 
     /// Softer, neutral gray for title shadows (avoids harsh pure black).
@@ -1002,9 +916,7 @@ enum UBDecor {
 /// Call this in your save actions to neatly resign the first responder before
 /// dismissing a sheet.  On macOS and other platforms this is a no‑op.
 func ub_dismissKeyboard() {
-    #if canImport(UIKit)
     UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-    #endif
 }
 
 // MARK: - Motion Provider Abstraction

--- a/OffshoreBudgeting/Systems/DesignSystem.swift
+++ b/OffshoreBudgeting/Systems/DesignSystem.swift
@@ -6,9 +6,7 @@
 
 import SwiftUI
 // MARK: Platform Color Imports
-#if canImport(UIKit)
 import UIKit
-#endif
 
 // MARK: - DesignSystem (Tokens)
 /// Centralized design tokens and tiny helpers for spacing, radius, shadows, and colors.
@@ -58,15 +56,11 @@ enum DesignSystem {
         // MARK: System‑Aware Container Background
         /// A dynamic background color that adapts to light/dark mode across UIKit platforms.
         static var containerBackground: Color {
-            #if canImport(UIKit)
             if #available(iOS 13.0, macCatalyst 13.0, *) {
                 return Color(UIColor.secondarySystemBackground)
             } else {
                 return Color(UIColor(white: 0.92, alpha: 1.0))
             }
-            #else
-            return Color.gray.opacity(0.12)
-            #endif
         }
 
         // MARK: Chip and Pill Fills

--- a/OffshoreBudgeting/Systems/PlatformCapabilities.swift
+++ b/OffshoreBudgeting/Systems/PlatformCapabilities.swift
@@ -27,14 +27,10 @@ extension PlatformCapabilities {
             supportsModernTranslucency = false
         }
 
-        #if canImport(UIKit)
         #if targetEnvironment(macCatalyst)
         let supportsAdaptiveKeypad = false
         #else
         let supportsAdaptiveKeypad = supportsModernTranslucency
-        #endif
-        #else
-        let supportsAdaptiveKeypad = false
         #endif
 
         return PlatformCapabilities(

--- a/OffshoreBudgeting/Systems/ResponsiveLayoutContext.swift
+++ b/OffshoreBudgeting/Systems/ResponsiveLayoutContext.swift
@@ -1,7 +1,5 @@
 import SwiftUI
-#if canImport(UIKit)
 import UIKit
-#endif
 
 /// Aggregates the environmental data points that influence how a layout should
 /// respond to changing device characteristics. Inject a single instance high in
@@ -20,28 +18,8 @@ struct ResponsiveLayoutContext: Equatable {
         case unspecified
 
         static var current: Idiom {
-            #if canImport(UIKit)
             #if targetEnvironment(macCatalyst)
             return .mac
-            #else
-            switch UIDevice.current.userInterfaceIdiom {
-            case .phone:
-                return .phone
-            case .pad:
-                return .pad
-            case .mac:
-                return .mac
-            case .carPlay:
-                return .car
-            default:
-                if #available(iOS 17.0, *) {
-                    if UIDevice.current.userInterfaceIdiom == .vision {
-                        return .vision
-                    }
-                }
-                return .unspecified
-            }
-            #endif
             #else
             return .unspecified
             #endif
@@ -141,7 +119,7 @@ struct ResponsiveLayoutReader<Content: View>: View {
     }
 
     private func resolvedSafeAreaInsets(from proxy: GeometryProxy) -> EdgeInsets {
-        if #available(iOS 15.0, macCatalyst 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             return proxy.safeAreaInsets
         } else {
             return legacySafeAreaInsets
@@ -151,7 +129,7 @@ struct ResponsiveLayoutReader<Content: View>: View {
 
 private struct LegacySafeAreaCapture: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, macCatalyst 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macCatalyst 15.0, *) {
             content
         } else {
             content.ub_captureSafeAreaInsets()

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -78,9 +78,7 @@ struct RootTabView: View {
             NavigationStack { content() }
         } else {
             NavigationView { content() }
-                #if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
-                #endif
         }
     }
 }

--- a/OffshoreBudgeting/Systems/SystemTheme.swift
+++ b/OffshoreBudgeting/Systems/SystemTheme.swift
@@ -1,7 +1,5 @@
 import SwiftUI
-#if canImport(UIKit)
 import UIKit
-#endif
 
 /// Central adapter that decides whether the system should use Liquid Glass (OS 26
 /// cycle) or Classic styling (earlier OS versions), and applies minimal global
@@ -23,7 +21,6 @@ enum SystemThemeAdapter {
     static func applyGlobalChrome(theme: AppTheme, colorScheme: ColorScheme?) {
         guard currentFlavor == .classic else { return }
 
-        #if canImport(UIKit)
         // UINavigationBar
         let navAppearance = UINavigationBarAppearance()
         navAppearance.configureWithOpaqueBackground()
@@ -52,7 +49,6 @@ enum SystemThemeAdapter {
         UIToolbar.appearance().standardAppearance = toolAppearance
         UIToolbar.appearance().compactAppearance = toolAppearance
         UIToolbar.appearance().scrollEdgeAppearance = toolAppearance
-        #endif
     }
 }
 

--- a/OffshoreBudgeting/Views/AddCardFormView.swift
+++ b/OffshoreBudgeting/Views/AddCardFormView.swift
@@ -15,6 +15,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 // MARK: - AddCardFormView
 /// Sheet that lets the user add or edit a card.
@@ -177,9 +178,7 @@ struct AddCardFormView: View {
         }
         onSave(trimmedName, selectedTheme)
         // iOS: nicely resign keyboard for a neat dismissal experience.
-        #if canImport(UIKit)
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        #endif
         return true
     }
 }

--- a/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddPlannedExpenseView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 import CoreData
 
 // MARK: - AddPlannedExpenseView
@@ -224,7 +225,6 @@ struct AddPlannedExpenseView: View {
             return true
         } catch {
             // Present error via UIKit alert on iOS; macOS simply returns false.
-            #if canImport(UIKit)
             let alert = UIAlertController(
                 title: "Couldn’t Save",
                 message: error.localizedDescription,
@@ -236,7 +236,6 @@ struct AddPlannedExpenseView: View {
                 .first?
                 .rootViewController?
                 .present(alert, animated: true)
-            #endif
             return false
         }
     }
@@ -371,15 +370,11 @@ private struct CategoryChipsRow: View {
 // A tiny compatibility wrapper to avoid directly calling presentationDetents on older OSes.
 private struct PresentationDetentsCompat: ViewModifier {
     func body(content: Content) -> some View {
-        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         if #available(iOS 16.0, *) {
             content.presentationDetents([.medium])
         } else {
             content
         }
-        #else
-        content
-        #endif
     }
 }
 

--- a/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
+++ b/OffshoreBudgeting/Views/AddUnplannedExpenseView.swift
@@ -11,6 +11,7 @@
 //
 
 import SwiftUI
+import UIKit
 import CoreData
 
 // MARK: - AddUnplannedExpenseView
@@ -152,7 +153,6 @@ struct AddUnplannedExpenseView: View {
             return true
         } catch {
             // Present error via UIKit alert on iOS; macOS simply returns false.
-            #if canImport(UIKit)
             let alert = UIAlertController(title: "Couldn’t Save", message: error.localizedDescription, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default))
             UIApplication.shared.connectedScenes
@@ -160,7 +160,6 @@ struct AddUnplannedExpenseView: View {
                 .first?
                 .rootViewController?
                 .present(alert, animated: true)
-            #endif
             return false
         }
     }

--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import UIKit
 import CoreData
 import Combine
 // MARK: - BudgetDetailsView
@@ -733,15 +734,10 @@ private extension View {
 
 private struct EqualWidthSegmentsModifier: ViewModifier {
     func body(content: Content) -> some View {
-        #if canImport(UIKit)
         content.background(EqualWidthSegmentApplier())
-        #else
-        content
-        #endif
     }
 }
 
-#if canImport(UIKit)
 private struct EqualWidthSegmentApplier: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
@@ -777,7 +773,6 @@ private struct EqualWidthSegmentApplier: UIViewRepresentable {
         return nil
     }
 }
-#endif
 
 // MARK: - PlannedListFR (List-backed; swipe enabled)
 private struct PlannedListFR: View {

--- a/OffshoreBudgeting/Views/Components/HomeViewHelpers.swift
+++ b/OffshoreBudgeting/Views/Components/HomeViewHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 // MARK: - Home Header Summary
 struct HomeHeaderContextSummary: View {
@@ -158,7 +159,6 @@ private struct HomeHeaderMinWidthModifier: ViewModifier {
 
 
 // MARK: - Header Action Helpers
-#if canImport(UIKit)
 struct HideMenuIndicatorIfPossible: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
@@ -169,7 +169,6 @@ struct HideMenuIndicatorIfPossible: ViewModifier {
         }
     }
 }
-#endif
 
 struct FilterBar: View {
     @Binding var sort: BudgetDetailsViewModel.SortOption

--- a/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
+++ b/OffshoreBudgeting/Views/CustomRecurrenceEditorView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 // MARK: - CustomRecurrence
 /// Lightweight model for building a simple RRULE:
@@ -136,9 +137,7 @@ struct CustomRecurrenceEditorView: View {
                         }
                 }
                 // Stack style is not available on macOS; apply only on platforms that support it.
-                #if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
-                #endif
             }
         }
         .ub_navigationBackground(

--- a/OffshoreBudgeting/Views/EditSheetScaffold.swift
+++ b/OffshoreBudgeting/Views/EditSheetScaffold.swift
@@ -11,9 +11,7 @@
 //
 
 import SwiftUI
-#if canImport(AppKit)
-import AppKit
-#endif
+import UIKit
 
 // MARK: - UBPresentationDetent (compat wrapper)
 // On iOS 16+ / macOS 13+, this bridges to SwiftUI.PresentationDetent.
@@ -24,7 +22,6 @@ enum UBPresentationDetent: Equatable, Hashable {
     case large
     case fraction(Double)
 
-    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     @available(iOS 16.0, *)
     var systemDetent: PresentationDetent {
         switch self {
@@ -33,7 +30,6 @@ enum UBPresentationDetent: Equatable, Hashable {
         case .fraction(let v): return .fraction(v)
         }
     }
-    #endif
 }
 
 // MARK: - EditSheetScaffold
@@ -55,9 +51,7 @@ struct EditSheetScaffold<Content: View>: View {
     @EnvironmentObject private var themeManager: ThemeManager
 
     // Selection state for detents (compat type)
-    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     @State private var detentSelection: UBPresentationDetent
-    #endif
 
     // MARK: Init
     init(
@@ -80,9 +74,7 @@ struct EditSheetScaffold<Content: View>: View {
         self.onCancel = onCancel
         self.onSave = onSave
         self.content = content()
-        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         _detentSelection = State(initialValue: initialDetent ?? detents.last ?? .medium)
-        #endif
     }
 
     // MARK: body
@@ -174,21 +166,11 @@ struct EditSheetScaffold<Content: View>: View {
     }
 
     private var separatorColor: Color {
-        #if canImport(UIKit)
         return Color(uiColor: .separator)
-        #elseif canImport(AppKit)
-        return Color(nsColor: .separatorColor)
-        #else
-        return Color.primary.opacity(0.2)
-        #endif
     }
 
     // MARK: Detent selection binding (iOS only)
-    #if canImport(UIKit) || targetEnvironment(macCatalyst)
     private var detentSelectionBinding: Binding<UBPresentationDetent>? { $detentSelection }
-    #else
-    private var detentSelectionBinding: Binding<UBPresentationDetent>? { nil }
-    #endif
 }
 
 // MARK: - Detents application helper
@@ -198,7 +180,6 @@ extension View {
         detents: [UBPresentationDetent],
         selection: Binding<UBPresentationDetent>?
     ) -> some View {
-        #if canImport(UIKit) || targetEnvironment(macCatalyst)
         if #available(iOS 16.0, *) {
             // Map compat detents to system detents
             let systemDetents = Set(detents.map { $0.systemDetent })
@@ -234,8 +215,5 @@ extension View {
         } else {
             return AnyView(self)
         }
-        #else
-        return self
-        #endif
     }
 }

--- a/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
+++ b/OffshoreBudgeting/Views/ExpenseCategoryManagerView.swift
@@ -9,12 +9,7 @@ import SwiftUI
 import CoreData
 
 // Conditionally import platform-specific frameworks for color conversions.
-#if canImport(UIKit)
 import UIKit
-#endif
-#if canImport(AppKit)
-import AppKit
-#endif
 
 // MARK: - ExpenseCategoryManagerView
 /// Full-fidelity management screen for Expense Categories.
@@ -305,19 +300,11 @@ struct ExpenseCategoryEditorSheet: View {
     /// Converts a SwiftUI `Color` into a `#RRGGBB` uppercase hex string.  Returns
     /// nil if conversion fails (e.g., color isn't representable in sRGB).
     private func colorToHex(_ color: Color) -> String? {
-        #if canImport(UIKit)
         let ui = UIColor(color)
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         guard ui.getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
         let ri = Int(round(r * 255)), gi = Int(round(g * 255)), bi = Int(round(b * 255))
         return String(format: "#%02X%02X%02X", ri, gi, bi)
-        #elseif canImport(AppKit)
-        guard let sRGB = NSColor(color).usingColorSpace(.sRGB) else { return nil }
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        sRGB.getRed(&r, green: &g, blue: &b, alpha: &a)
-        let ri = Int(round(r * 255)), gi = Int(round(g * 255)), bi = Int(round(b * 255))
-        return String(format: "#%02X%02X%02X", ri, gi, bi)
-        #endif
     }
 }
 

--- a/OffshoreBudgeting/Views/HelpView.swift
+++ b/OffshoreBudgeting/Views/HelpView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Comprehensive in-app guide that mirrors the app's documented structure.
 /// Each section pulls from `// MARK:` comments across the codebase so users can
@@ -18,9 +19,7 @@ struct HelpView: View {
                     helpMenu
                         .navigationBarTitle("Help")
                 }
-#if canImport(UIKit)
                 .navigationViewStyle(StackNavigationViewStyle())
-#endif
             }
         }
         .ub_navigationBackground(

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import UIKit
 import CoreData
 import Foundation
 import Combine
@@ -27,9 +28,7 @@ struct HomeView: View {
     @StateObject private var vm = HomeViewModel()
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.platformCapabilities) private var capabilities
-#if canImport(UIKit)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-#endif
     @AppStorage(AppSettingsKeys.budgetPeriod.rawValue) private var budgetPeriodRawValue: String = BudgetPeriod.monthly.rawValue
     private var budgetPeriod: BudgetPeriod { BudgetPeriod(rawValue: budgetPeriodRawValue) ?? .monthly }
     @State private var selectedSegment: BudgetDetailsViewModel.Segment = .planned
@@ -62,9 +61,7 @@ struct HomeView: View {
     // Reset header width matching on trait changes (e.g., rotation) to avoid
     // stale measurements forcing an oversized minWidth when returning from
     // landscape → portrait. This keeps the period navigation rendering stable.
-#if canImport(UIKit)
     @Environment(\.verticalSizeClass) private var verticalSizeClass
-#endif
 
     // MARK: Body
     var body: some View {
@@ -136,10 +133,8 @@ struct HomeView: View {
         .alert(item: $vm.alert, content: alert(for:))
         // Clear cached/matched widths when key traits change so controls can
         // re-measure for the new size class/orientation.
-#if canImport(UIKit)
         .ub_onChange(of: horizontalSizeClass) { _ in resetHeaderWidthMatching() }
         .ub_onChange(of: verticalSizeClass) { _ in resetHeaderWidthMatching() }
-#endif
     }
 
     private var headerSection: some View {
@@ -976,15 +971,10 @@ private extension View {
 
 private struct HomeEqualWidthSegmentsModifier: ViewModifier {
     func body(content: Content) -> some View {
-        #if canImport(UIKit)
         content.background(HomeEqualWidthSegmentApplier())
-        #else
-        content
-        #endif
     }
 }
 
-#if canImport(UIKit)
 private struct HomeEqualWidthSegmentApplier: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
@@ -1014,7 +1004,6 @@ private struct HomeEqualWidthSegmentApplier: UIViewRepresentable {
         return nil
     }
 }
-#endif
 
 // MARK: - Utility: Height measurement helper
 private struct ViewHeightKey: PreferenceKey {

--- a/OffshoreBudgeting/Views/OnboardingView.swift
+++ b/OffshoreBudgeting/Views/OnboardingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import Combine
 
 // MARK: - OnboardingView
@@ -362,9 +363,7 @@ private struct CardsStep: View {
 
     private func navigationView<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationView { content() }
-        #if canImport(UIKit)
             .navigationViewStyle(.stack)
-        #endif
     }
 }
 
@@ -655,9 +654,7 @@ private struct CategoriesStep: View {
 
     private func navigationView<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         NavigationView { content() }
-        #if canImport(UIKit)
             .navigationViewStyle(.stack)
-        #endif
     }
 }
 
@@ -934,9 +931,7 @@ private struct CloudOptionToggle: View {
             Toggle("", isOn: $isOn)
                 .labelsHidden()
                 .disabled(!isEnabled)
-#if canImport(UIKit)
                 .controlSize(.large)
-#endif
         }
         .padding(.vertical, DS.Spacing.s)
         .opacity(isEnabled ? 1 : 0.45)

--- a/OffshoreBudgeting/Views/UBEmptyState.swift
+++ b/OffshoreBudgeting/Views/UBEmptyState.swift
@@ -17,6 +17,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 // MARK: - UBEmptyState
 /// Standardized empty-state presentation with optional action buttons.
@@ -106,11 +107,7 @@ struct UBEmptyState: View {
     }
 
     private var resolvedVerticalPadding: CGFloat {
-        #if canImport(UIKit)
         return verticalSizeClass == .compact ? DS.Spacing.s : DS.Spacing.m
-        #else
-        return DS.Spacing.m
-        #endif
     }
 
     private var onboardingTint: Color {
@@ -146,7 +143,6 @@ struct UBEmptyState: View {
             .labelStyle(.titleAndIcon)
     }
 
-#if canImport(UIKit)
     @ViewBuilder
     private func glassPrimaryButton(
         title: String,
@@ -185,50 +181,8 @@ struct UBEmptyState: View {
             .glassEffect(in: capsule)
         }
     }
-#else
-    @ViewBuilder
-    private func glassPrimaryButton(
-        title: String,
-        fallbackTint: Color,
-        glassTint: Color,
-        action: @escaping () -> Void
-    ) -> some View {
-        if capabilities.supportsOS26Translucency, #available(macCatalyst 26.0, *) {
-            glassStyledPrimaryButton(title: title, glassTint: glassTint, action: action)
-        } else {
-            legacyPrimaryButton(title: title, action: action)
-        }
-    }
 
-    @available(macCatalyst 26.0, *)
-    @ViewBuilder
-    private func glassStyledPrimaryButton(
-        title: String,
-        glassTint: Color,
-        action: @escaping () -> Void
-    ) -> some View {
-        let capsule = Capsule(style: .continuous)
-        GlassEffectContainer {
-            Button(action: action) {
-                Label(title, systemImage: "plus")
-                    .labelStyle(.titleAndIcon)
-                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary)
-                    .padding(.horizontal, DS.Spacing.xl)
-                    .padding(.vertical, DS.Spacing.m)
-                    .contentShape(capsule)
-            }
-            .tint(glassTint)
-            .buttonStyle(.plain)
-            .frame(maxWidth: 320)
-            .glassEffect(in: capsule)
-        }
-    }
-#endif
-
-    #if canImport(UIKit)
     @Environment(\.verticalSizeClass) private var verticalSizeClass
-    #endif
     private var primaryButtonTint: Color {
         themeManager.selectedTheme.resolvedTint
     }


### PR DESCRIPTION
## Summary
- remove remaining `#if canImport` checks so UIKit features are always compiled for the Catalyst build
- trim macOS-specific availability branches in theme and compatibility helpers to rely on iOS/macCatalyst APIs
- add the necessary UIKit imports to views and scaffolds that now use UIKit symbols unconditionally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f3b1e4b0832ca04a15b1c03e988f