### PR TITLE
feat: allow hidden root tab headers

### DIFF
--- a/OffshoreBudgeting/Views/CardsView.swift
+++ b/OffshoreBudgeting/Views/CardsView.swift
@@ -47,7 +47,7 @@ struct CardsView: View {
     // MARK: Body
     var body: some View {
         RootTabPageScaffold(scrollBehavior: .always, spacing: DS.Spacing.s) {
-            RootViewTopPlanes(title: "Cards") {
+            RootViewTopPlanes(title: "Cards", titleDisplayMode: .hidden) {
                 addCardButton
             }
         } content: { proxy in

--- a/OffshoreBudgeting/Views/Components/RootTabHeader.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabHeader.swift
@@ -22,7 +22,7 @@ struct RootTabHeader<Trailing: View>: View {
     // MARK: Properties
     @Environment(\.ub_safeAreaInsets) private var safeAreaInsets
     @Environment(\.responsiveLayoutContext) private var responsiveLayoutContext
-    private let title: String
+    private let title: String?
     private let horizontalPadding: CGFloat
     private let topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle
     private let trailingPlacement: RootTabHeaderLayout.TrailingPlacement
@@ -30,7 +30,7 @@ struct RootTabHeader<Trailing: View>: View {
 
     // MARK: Init
     init(
-        title: String,
+        title: String?,
         horizontalPadding: CGFloat = RootTabHeaderLayout.defaultHorizontalPadding,
         topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle = .standard,
         trailingPlacement: RootTabHeaderLayout.TrailingPlacement = .right,
@@ -44,7 +44,7 @@ struct RootTabHeader<Trailing: View>: View {
     }
 
     init(
-        title: String,
+        title: String?,
         horizontalPadding: CGFloat = RootTabHeaderLayout.defaultHorizontalPadding,
         topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle = .standard,
         trailingPlacement: RootTabHeaderLayout.TrailingPlacement = .right
@@ -59,19 +59,23 @@ struct RootTabHeader<Trailing: View>: View {
     // MARK: Body
     var body: some View {
         headerStack
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, horizontalPadding)
-        .padding(.top, resolvedTopPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.top, resolvedTopPadding)
     }
 
     private var headerStack: some View {
         HStack(alignment: .top, spacing: DS.Spacing.m) {
-            Text(title)
-                .font(.largeTitle.bold())
-                .lineLimit(1)
-                .minimumScaleFactor(0.85)
-                .accessibilityAddTraits(.isHeader)
-                .frame(maxWidth: trailingPlacement == .right ? .infinity : nil, alignment: .leading)
+            if let title {
+                Text(title)
+                    .font(.largeTitle.bold())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                    .accessibilityAddTraits(.isHeader)
+                    .frame(maxWidth: trailingPlacement == .right ? .infinity : nil, alignment: .leading)
+            } else if trailingPlacement == .right {
+                Spacer(minLength: 0)
+            }
 
             trailing()
 

--- a/OffshoreBudgeting/Views/Components/RootViewTopPlanes.swift
+++ b/OffshoreBudgeting/Views/Components/RootViewTopPlanes.swift
@@ -3,7 +3,12 @@ import SwiftUI
 /// Provides a consistent header for root tab screens, keeping the large title and
 /// optional trailing actions aligned on the same horizontal plane.
 struct RootViewTopPlanes<ActionContent: View>: View {
-    private let title: String
+    enum TitleDisplayMode {
+        case visible
+        case hidden
+    }
+
+    private let resolvedTitle: String?
     private let horizontalPadding: CGFloat
     private let actionContent: ActionContent?
     private let topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle
@@ -11,11 +16,12 @@ struct RootViewTopPlanes<ActionContent: View>: View {
 
     init(
         title: String,
+        titleDisplayMode: TitleDisplayMode = .visible,
         horizontalPadding: CGFloat = RootTabHeaderLayout.defaultHorizontalPadding,
         topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle = .standard,
         trailingPlacement: RootTabHeaderLayout.TrailingPlacement = .right
     ) where ActionContent == EmptyView {
-        self.title = title
+        self.resolvedTitle = Self.resolveTitle(title, for: titleDisplayMode)
         self.horizontalPadding = horizontalPadding
         self.actionContent = nil
         self.topPaddingStyle = topPaddingStyle
@@ -24,12 +30,13 @@ struct RootViewTopPlanes<ActionContent: View>: View {
 
     init(
         title: String,
+        titleDisplayMode: TitleDisplayMode = .visible,
         horizontalPadding: CGFloat = RootTabHeaderLayout.defaultHorizontalPadding,
         topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle = .standard,
         trailingPlacement: RootTabHeaderLayout.TrailingPlacement = .right,
         @ViewBuilder actions: () -> ActionContent
     ) {
-        self.title = title
+        self.resolvedTitle = Self.resolveTitle(title, for: titleDisplayMode)
         self.horizontalPadding = horizontalPadding
         self.actionContent = actions()
         self.topPaddingStyle = topPaddingStyle
@@ -38,22 +45,33 @@ struct RootViewTopPlanes<ActionContent: View>: View {
 
     @ViewBuilder
     var body: some View {
-        if let actionContent {
-            RootTabHeader(
-                title: title,
-                horizontalPadding: horizontalPadding,
-                topPaddingStyle: topPaddingStyle,
-                trailingPlacement: trailingPlacement
-            ) {
-                actionContent
+        if resolvedTitle != nil || actionContent != nil {
+            if let actionContent {
+                RootTabHeader(
+                    title: resolvedTitle,
+                    horizontalPadding: horizontalPadding,
+                    topPaddingStyle: topPaddingStyle,
+                    trailingPlacement: trailingPlacement
+                ) {
+                    actionContent
+                }
+            } else {
+                RootTabHeader(
+                    title: resolvedTitle,
+                    horizontalPadding: horizontalPadding,
+                    topPaddingStyle: topPaddingStyle,
+                    trailingPlacement: trailingPlacement
+                )
             }
-        } else {
-            RootTabHeader(
-                title: title,
-                horizontalPadding: horizontalPadding,
-                topPaddingStyle: topPaddingStyle,
-                trailingPlacement: trailingPlacement
-            )
+        }
+    }
+
+    private static func resolveTitle(_ title: String, for mode: TitleDisplayMode) -> String? {
+        switch mode {
+        case .visible:
+            return title
+        case .hidden:
+            return nil
         }
     }
 }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -141,6 +141,7 @@ struct HomeView: View {
         VStack(alignment: .leading, spacing: headerSectionSpacing) {
             RootViewTopPlanes(
                 title: "Home",
+                titleDisplayMode: .hidden,
                 topPaddingStyle: .navigationBarAligned,
                 trailingPlacement: .right
             ) {

--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -144,7 +144,7 @@ struct IncomeView: View {
     // MARK: Body
     var body: some View {
         RootTabPageScaffold(spacing: DS.Spacing.s) {
-            RootViewTopPlanes(title: "Income") {
+            RootViewTopPlanes(title: "Income", titleDisplayMode: .hidden) {
                 addIncomeButton
             }
         } content: { proxy in

--- a/OffshoreBudgeting/Views/PresetsView.swift
+++ b/OffshoreBudgeting/Views/PresetsView.swift
@@ -31,7 +31,7 @@ struct PresetsView: View {
         // jank/freezes on iOS 26. Let the List own scrolling by disabling
         // the scaffold's automatic wrapping.
         RootTabPageScaffold(spacing: DS.Spacing.s, wrapsContentInScrollView: false) {
-            RootViewTopPlanes(title: "Presets") {
+            RootViewTopPlanes(title: "Presets", titleDisplayMode: .hidden) {
                 addPresetButton
             }
         } content: { proxy in

--- a/OffshoreBudgeting/Views/SettingsView.swift
+++ b/OffshoreBudgeting/Views/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
             scrollBehavior: .always,
             spacing: cardStackSpacing
         ) { _ in
-            RootViewTopPlanes(title: "Settings", horizontalPadding: horizontalPadding)
+            RootViewTopPlanes(title: "Settings", titleDisplayMode: .hidden, horizontalPadding: horizontalPadding)
                 .padding(.top, scrollViewTopPadding)
         } content: { proxy in
             content(using: proxy)


### PR DESCRIPTION
## Summary
- add a title display mode to `RootViewTopPlanes` so headers can collapse when their title is hidden
- update `RootTabHeader` to render optional titles while preserving trailing action alignment
- hide redundant top plane titles on the Home, Income, Cards, Presets, and Settings root screens

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da0051b4c0832c9c5e188d663d74ec