### PR TITLE
fix: hide root navigation chrome on root tabs

### DIFF
--- a/OffshoreBudgeting/Systems/Compatibility.swift
+++ b/OffshoreBudgeting/Systems/Compatibility.swift
@@ -126,6 +126,18 @@ extension View {
         modifier(UBRootTabNavigationTitleModifier(title: title))
     }
 
+    // MARK: ub_rootNavigationChrome()
+    /// Hides the navigation bar background for root-level navigation stacks on modern OS releases.
+    /// Earlier platforms ignore the call so they retain their default opaque chrome.
+    @ViewBuilder
+    func ub_rootNavigationChrome() -> some View {
+        if #available(iOS 16.0, macCatalyst 16.0, *) {
+            self.toolbarBackground(.hidden, for: .navigationBar)
+        } else {
+            self
+        }
+    }
+
     // MARK: ub_cardTitleShadow()
     /// Tight, offset shadow for card titles (small 3D lift). Softer gray tone, not harsh black.
     /// Use on text layers: `.ub_cardTitleShadow()`

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -50,10 +50,7 @@ struct RootTabView: View {
     @ViewBuilder
     private func decoratedTabContent(for tab: Tab) -> some View {
         tabContent(for: tab)
-            .ub_navigationBackground(
-                theme: themeManager.selectedTheme,
-                configuration: themeManager.glassConfiguration
-            )
+            .ub_rootNavigationChrome()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- add a reusable root navigation chrome modifier that hides toolbar backgrounds on OS 16+
- adopt the modifier in the root tab view so tab stacks no longer paint the themed backdrop

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68da01794ba8832c9b896bae0fdb5a3f