### PR TITLE
feat: move income add control to toolbar

### DIFF
--- a/OffshoreBudgeting/Views/IncomeView.swift
+++ b/OffshoreBudgeting/Views/IncomeView.swift
@@ -124,13 +124,12 @@ struct IncomeView: View {
     }
 
     private var addIncomeButton: some View {
-        RootHeaderIconActionButton(
-            systemImage: "plus",
-            accessibilityLabel: "Add Income",
-            accessibilityIdentifier: "add_income_button"
-        ) {
-            beginAddingIncome()
+        Button(action: { beginAddingIncome() }) {
+            Image(systemName: "plus")
+                .imageScale(.medium)
         }
+        .accessibilityLabel("Add Income")
+        .accessibilityIdentifier("add_income_button")
     }
 
     // MARK: Calendar
@@ -144,9 +143,7 @@ struct IncomeView: View {
     // MARK: Body
     var body: some View {
         RootTabPageScaffold(spacing: DS.Spacing.s) {
-            RootViewTopPlanes(title: "Income", titleDisplayMode: .hidden) {
-                addIncomeButton
-            }
+            EmptyView()
         } content: { proxy in
             content(using: proxy)
         }
@@ -182,6 +179,11 @@ struct IncomeView: View {
             navigate(to: initial)
         }
         .ub_tabNavigationTitle("Income")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                addIncomeButton
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- drop the RootViewTopPlanes header from IncomeView so the screen content starts directly beneath the navigation title
- expose the add-income affordance as a toolbar button that triggers the existing add flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da05757cb0832c9dda68e4f612fae3