### PR TITLE
fix(view): match cards add button styling

### DIFF
--- a/OffshoreBudgeting/Views/CardsView.swift
+++ b/OffshoreBudgeting/Views/CardsView.swift
@@ -112,31 +112,17 @@ struct CardsView: View {
     }
 
     private var addActionToolbarButton: some View {
-        Menu {
-            Button {
-                isPresentingAddCard = true
-            } label: {
-                Label("Add Card", systemImage: "creditcard")
-            }
-
-            Button {
-                isPresentingAddExpense = true
-            } label: {
-                Label("Add Expense", systemImage: "plus.forwardslash.minus")
-            }
-            .disabled(selectedCardStableID == nil)
-        } label: {
-            Image(systemName: "plus.circle.fill")
-                .symbolRenderingMode(.hierarchical)
-                .font(.title3)
-                .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
-        } primaryAction: {
+        Button {
             if selectedCardStableID == nil {
                 isPresentingAddCard = true
             } else {
                 isPresentingAddExpense = true
             }
+        } label: {
+            Image(systemName: "plus")
+                .imageScale(.medium)
         }
+        .accessibilityLabel(selectedCardStableID == nil ? "Add Card" : "Add Expense")
     }
 
     // MARK: - Content View (Type-Safe)


### PR DESCRIPTION
## Summary
- update the Cards tab toolbar to use the standard plus icon button shared across other views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da083e0e10832cbba1e091a90f2e78