### PR TITLE
fix: restore legacy navigation chrome background

### DIFF
--- a/OffshoreBudgeting/Systems/Compatibility.swift
+++ b/OffshoreBudgeting/Systems/Compatibility.swift
@@ -131,11 +131,7 @@ extension View {
     /// Earlier platforms ignore the call so they retain their default opaque chrome.
     @ViewBuilder
     func ub_rootNavigationChrome() -> some View {
-        if #available(iOS 16.0, macCatalyst 16.0, *) {
-            self.toolbarBackground(.hidden, for: .navigationBar)
-        } else {
-            self
-        }
+        modifier(UBRootNavigationChromeModifier())
     }
 
     // MARK: ub_cardTitleShadow()
@@ -417,6 +413,23 @@ private struct UBPreOS26ListRowBackgroundModifier: ViewModifier {
 }
 
 // MARK: - Root Tab Navigation Title Styling
+private struct UBRootNavigationChromeModifier: ViewModifier {
+    @Environment(\.platformCapabilities) private var capabilities
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if UBGlassBackgroundPolicy.shouldUseSystemChrome(capabilities: capabilities) {
+            if #available(iOS 16.0, macCatalyst 16.0, *) {
+                content.toolbarBackground(.hidden, for: .navigationBar)
+            } else {
+                content
+            }
+        } else {
+            content
+        }
+    }
+}
+
 private struct UBRootTabNavigationTitleModifier: ViewModifier {
     let title: String
 

--- a/OffshoreBudgeting/Systems/RootTabView.swift
+++ b/OffshoreBudgeting/Systems/RootTabView.swift
@@ -50,6 +50,10 @@ struct RootTabView: View {
     @ViewBuilder
     private func decoratedTabContent(for tab: Tab) -> some View {
         tabContent(for: tab)
+            .ub_navigationBackground(
+                theme: themeManager.selectedTheme,
+                configuration: themeManager.glassConfiguration
+            )
             .ub_rootNavigationChrome()
     }
 


### PR DESCRIPTION
## Summary
- gate the root navigation chrome modifier on platform capabilities so legacy builds keep an opaque bar
- chain the themed navigation background before applying the root chrome modifier in the tab view

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db123c5954832cb1f71ea845d2b80d