### PR TITLE
feat: theme-aware root header icons

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
+++ b/OffshoreBudgeting/Views/Components/RootHeaderActions.swift
@@ -40,6 +40,7 @@ enum RootHeaderControlSizing {
 
 // MARK: - Icon Content
 struct RootHeaderControlIcon: View {
+    @EnvironmentObject private var themeManager: ThemeManager
     var systemImage: String
     /// Optional symbol variant override keeps headers in sync with design
     /// specifications when SF Symbols offer multiple contextual variants.
@@ -49,7 +50,7 @@ struct RootHeaderControlIcon: View {
         configuredImage
             .font(.system(size: 18, weight: .semibold))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .foregroundStyle(.primary)
+            .foregroundStyle(iconForegroundStyle)
     }
 
     @ViewBuilder
@@ -59,6 +60,17 @@ struct RootHeaderControlIcon: View {
                 .symbolVariant(symbolVariants)
         } else {
             Image(systemName: systemImage)
+        }
+    }
+
+    private var iconForegroundStyle: AnyShapeStyle {
+        let theme = themeManager.selectedTheme
+
+        switch theme {
+        case .system:
+            return AnyShapeStyle(.primary)
+        default:
+            return AnyShapeStyle(theme.resolvedTint)
         }
     }
 


### PR DESCRIPTION
## Summary
- inject ThemeManager into RootHeaderControlIcon to access the active AppTheme
- replace the hard-coded foreground style with a reusable theme-aware tint resolver

## Testing
- xcodebuild -project "OffshoreBudgeting.xcodeproj" -scheme OffshoreBudgeting -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db1492f4c8832cb6263afc36d61a3e