### PR TITLE
Fix empty budget lists to avoid nested scroll containers

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -702,6 +702,10 @@ private struct PlannedListFR: View {
     @Environment(\.platformCapabilities) private var capabilities
     @AppStorage(AppSettingsKeys.confirmBeforeDelete.rawValue) private var confirmBeforeDelete: Bool = true
 
+    private var containerHeight: CGFloat {
+        max(layoutContext.containerSize.height - (layoutContext.safeArea.top + layoutContext.safeArea.bottom), 0)
+    }
+
     init(
         budget: Budget,
         startDate: Date,
@@ -736,22 +740,11 @@ private struct PlannedListFR: View {
         let items = sorted(rows)
         Group {
             if items.isEmpty {
-                // MARK: Compact empty state (single Add button)
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: DS.Spacing.m) {
-                        addActionButton(title: "Add Planned Expense", action: onAddTapped)
-                            .padding(.horizontal, DS.Spacing.l)
-                        Text("No planned expenses in this period.")
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: .infinity)
-                            .padding(.horizontal, DS.Spacing.l)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .top)
-                }
-                .refreshable { onTotalsChanged() }
-                .ub_ignoreSafeArea(edges: .bottom)
-        } else {
+                emptyStateList(
+                    buttonTitle: "Add Planned Expense",
+                    message: "No planned expenses in this period."
+                )
+            } else {
                 // MARK: Real List for native swipe
                 List {
                     if let header {
@@ -763,7 +756,7 @@ private struct PlannedListFR: View {
                 .styledList()
                 .ub_ignoreSafeArea(edges: .bottom)
                 .applyListHorizontalPadding(capabilities)
-        }
+            }
         }
         .sheet(item: $editingItem) { expense in
             AddPlannedExpenseView(
@@ -784,6 +777,37 @@ private struct PlannedListFR: View {
         } message: { _ in
             Text("This will remove the planned expense.")
         }
+    }
+
+    @ViewBuilder
+    private func emptyStateList(buttonTitle: String, message: String) -> some View {
+        List {
+            if let header {
+                headerSection(header)
+            }
+            emptyStateRow(buttonTitle: buttonTitle, message: message)
+        }
+        .refreshable { onTotalsChanged() }
+        .styledList()
+        .ub_ignoreSafeArea(edges: .bottom)
+        .applyListHorizontalPadding(capabilities)
+    }
+
+    @ViewBuilder
+    private func emptyStateRow(buttonTitle: String, message: String) -> some View {
+        VStack(spacing: DS.Spacing.m) {
+            addActionButton(title: buttonTitle, action: onAddTapped)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, DS.Spacing.l)
+        }
+        .frame(maxWidth: .infinity, minHeight: containerHeight, alignment: .top)
+        .padding(.vertical, DS.Spacing.l)
+        .listRowInsets(EdgeInsets(top: 0, leading: DS.Spacing.l, bottom: 0, trailing: DS.Spacing.l))
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
     }
 
     // MARK: Local: Add action button with OS-aware styling
@@ -960,6 +984,10 @@ private struct VariableListFR: View {
     @Environment(\.platformCapabilities) private var capabilities
     @AppStorage(AppSettingsKeys.confirmBeforeDelete.rawValue) private var confirmBeforeDelete: Bool = true
 
+    private var containerHeight: CGFloat {
+        max(layoutContext.containerSize.height - (layoutContext.safeArea.top + layoutContext.safeArea.bottom), 0)
+    }
+
     init(
         attachedCards: [Card],
         startDate: Date,
@@ -1001,21 +1029,10 @@ private struct VariableListFR: View {
         let items = sorted(rows)
         Group {
             if items.isEmpty {
-                // MARK: Compact empty state (single Add button)
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: DS.Spacing.m) {
-                        addActionButton(title: "Add Variable Expense", action: onAddTapped)
-                            .padding(.horizontal, DS.Spacing.l)
-                        Text("No variable expenses in this period.")
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: .infinity)
-                            .padding(.horizontal, DS.Spacing.l)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .top)
-                }
-                .refreshable { onTotalsChanged() }
-                .ub_ignoreSafeArea(edges: .bottom)
+                emptyStateList(
+                    buttonTitle: "Add Variable Expense",
+                    message: "No variable expenses in this period."
+                )
             } else {
                 // MARK: Real List for native swipe
                 List {
@@ -1050,6 +1067,37 @@ private struct VariableListFR: View {
         } message: { _ in
             Text("This will remove the expense.")
         }
+    }
+
+    @ViewBuilder
+    private func emptyStateList(buttonTitle: String, message: String) -> some View {
+        List {
+            if let header {
+                headerSection(header)
+            }
+            emptyStateRow(buttonTitle: buttonTitle, message: message)
+        }
+        .refreshable { onTotalsChanged() }
+        .styledList()
+        .ub_ignoreSafeArea(edges: .bottom)
+        .applyListHorizontalPadding(capabilities)
+    }
+
+    @ViewBuilder
+    private func emptyStateRow(buttonTitle: String, message: String) -> some View {
+        VStack(spacing: DS.Spacing.m) {
+            addActionButton(title: buttonTitle, action: onAddTapped)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, DS.Spacing.l)
+        }
+        .frame(maxWidth: .infinity, minHeight: containerHeight, alignment: .top)
+        .padding(.vertical, DS.Spacing.l)
+        .listRowInsets(EdgeInsets(top: 0, leading: DS.Spacing.l, bottom: 0, trailing: DS.Spacing.l))
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
     }
 
     // MARK: Local: Add action button with OS-aware styling


### PR DESCRIPTION
## Summary
- replace ScrollView-based empty states in the planned expenses list with a styled List row so the surrounding scaffold remains the sole scroll host
- mirror the same empty-state treatment for variable expenses and keep pull-to-refresh attached to the scrolling List
- size the empty state content with the responsive layout context to keep the call-to-action pinned toward the top

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db27948058832c81ceac772d662164