### PR TITLE
fix(view): align HomeView scaffold usage

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -29,7 +29,6 @@ struct HomeView: View {
     private var budgetPeriod: BudgetPeriod { BudgetPeriod(rawValue: budgetPeriodRawValue) ?? .monthly }
     @State private var selectedSegment: BudgetDetailsViewModel.Segment = .planned
     @State private var homeSort: BudgetDetailsViewModel.SortOption = .dateNewOld
-    @State private var headerContentHeight: CGFloat = 0
 
     // MARK: Add Budget Sheet
     @State private var isPresentingAddBudget: Bool = false
@@ -50,20 +49,14 @@ struct HomeView: View {
         RootTabPageScaffold(
             scrollBehavior: .auto,
             spacing: headerContentSpacing
-        ) {
-            EmptyView()
+        ) { _ in
+            headerSection
         } content: { proxy in
-            let availableContentHeight = resolvedAvailableContentHeight(using: proxy)
-
-            VStack(alignment: .leading, spacing: headerContentSpacing) {
-                headerSection
-                contentContainer(
-                    proxy: proxy,
-                    availableContentHeight: availableContentHeight
-                )
-            }
+            contentContainer(
+                proxy: proxy,
+                availableContentHeight: max(proxy.availableHeightBelowHeader, 0)
+            )
             .frame(maxWidth: .infinity, alignment: .top)
-            .onPreferenceChange(HomeHeaderHeightPreferenceKey.self) { headerContentHeight = $0 }
             .rootTabContentPadding(
                 proxy,
                 horizontal: 0,
@@ -144,15 +137,6 @@ struct HomeView: View {
             onAdjustPeriod: { delta in vm.adjustSelectedPeriod(by: delta) }
         )
         .padding(.horizontal, RootTabHeaderLayout.defaultHorizontalPadding)
-        .background(
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(
-                        key: HomeHeaderHeightPreferenceKey.self,
-                        value: proxy.size.height
-                    )
-            }
-        )
     }
 
     // MARK: Toolbar Actions
@@ -358,7 +342,7 @@ struct HomeView: View {
         proxy: RootTabPageProxy,
         availableContentHeight: CGFloat
     ) -> some View {
-        let fallbackHeight = proxy.availableHeight - proxy.headerHeight
+        let fallbackHeight = proxy.availableHeightBelowHeader
         let resolvedHeight = max(availableContentHeight > 0 ? availableContentHeight : fallbackHeight, 1)
 
         RootTabListHostingContainer(height: resolvedHeight) {
@@ -401,11 +385,6 @@ struct HomeView: View {
     }
 
     private var headerContentSpacing: CGFloat { DS.Spacing.s }
-
-    private func resolvedAvailableContentHeight(using proxy: RootTabPageProxy) -> CGFloat {
-        let spacingContribution = headerContentHeight > 0 ? headerContentSpacing : 0
-        return max(proxy.availableHeight - headerContentHeight - spacingContribution, 0)
-    }
 
     private var primarySummary: BudgetSummary? {
         if case .loaded(let summaries) = vm.state {
@@ -747,14 +726,6 @@ private enum HomeHeaderOverviewMetrics {
     static let valueFont: Font = .body.weight(.semibold)
     static let totalValueFont: Font = .title3.weight(.semibold)
     static let fallbackCurrencyCode = "USD"
-}
-
-private struct HomeHeaderHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(0, nextValue())
-    }
 }
 
 // MARK: - Segmented control sizing helpers


### PR DESCRIPTION
## Summary
- update HomeView to pass the overview header through RootTabPageScaffold’s header closure
- size the list hosting container using the scaffold proxy’s available height below the header to remove custom geometry tracking

## Testing
- not run (simulator unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68db3357e7f0832c9086e84ee2cd1930