### PR TITLE
fix: align HomeView header with scaffold

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -29,7 +29,6 @@ struct HomeView: View {
     private var budgetPeriod: BudgetPeriod { BudgetPeriod(rawValue: budgetPeriodRawValue) ?? .monthly }
     @State private var selectedSegment: BudgetDetailsViewModel.Segment = .planned
     @State private var homeSort: BudgetDetailsViewModel.SortOption = .dateNewOld
-    @State private var headerContentHeight: CGFloat = 0
 
     // MARK: Add Budget Sheet
     @State private var isPresentingAddBudget: Bool = false
@@ -51,25 +50,16 @@ struct HomeView: View {
             scrollBehavior: .auto,
             spacing: headerContentSpacing
         ) {
-            EmptyView()
+            headerSection
         } content: { proxy in
-            let availableContentHeight = resolvedAvailableContentHeight(using: proxy)
-
-            VStack(alignment: .leading, spacing: headerContentSpacing) {
-                headerSection
-                contentContainer(
-                    proxy: proxy,
-                    availableContentHeight: availableContentHeight
+            contentContainer(proxy: proxy)
+                .frame(maxWidth: .infinity, alignment: .top)
+                .rootTabContentPadding(
+                    proxy,
+                    horizontal: 0,
+                    includeSafeArea: false,
+                    tabBarGutter: proxy.compactAwareTabBarGutter
                 )
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
-            .onPreferenceChange(HomeHeaderHeightPreferenceKey.self) { headerContentHeight = $0 }
-            .rootTabContentPadding(
-                proxy,
-                horizontal: 0,
-                includeSafeArea: false,
-                tabBarGutter: proxy.compactAwareTabBarGutter
-            )
         }
         .ub_tabNavigationTitle("Home")
         .toolbar {
@@ -144,15 +134,6 @@ struct HomeView: View {
             onAdjustPeriod: { delta in vm.adjustSelectedPeriod(by: delta) }
         )
         .padding(.horizontal, RootTabHeaderLayout.defaultHorizontalPadding)
-        .background(
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(
-                        key: HomeHeaderHeightPreferenceKey.self,
-                        value: proxy.size.height
-                    )
-            }
-        )
     }
 
     // MARK: Toolbar Actions
@@ -293,7 +274,7 @@ struct HomeView: View {
     }
 
     // MARK: Content Container
-    private func contentContainer(proxy: RootTabPageProxy, availableContentHeight: CGFloat) -> some View {
+    private func contentContainer(proxy: RootTabPageProxy) -> some View {
         Group {
             switch vm.state {
             case .initial:
@@ -306,17 +287,16 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
 
             case .empty:
-                emptyPeriodContent(availableContentHeight: availableContentHeight)
+                emptyPeriodContent(proxy: proxy)
 
             case .loaded(let summaries):
                 if let first = summaries.first {
                     loadedBudgetContent(
                         for: first,
-                        proxy: proxy,
-                        availableContentHeight: availableContentHeight
+                        proxy: proxy
                     )
                 } else {
-                    emptyPeriodContent(availableContentHeight: availableContentHeight)
+                    emptyPeriodContent(proxy: proxy)
                 }
             }
         }
@@ -324,7 +304,9 @@ struct HomeView: View {
 
     // MARK: Empty Period Content (replaces generic empty state)
     @ViewBuilder
-    private func emptyPeriodContent(availableContentHeight: CGFloat) -> some View {
+    private func emptyPeriodContent(proxy: RootTabPageProxy) -> some View {
+        let availableContentHeight = proxy.availableHeightBelowHeader
+
         VStack(alignment: .leading, spacing: DS.Spacing.m) {
             // Always-offer Add button when no budget exists so users can
             // quickly create an expense for this period.
@@ -355,11 +337,9 @@ struct HomeView: View {
     @ViewBuilder
     private func loadedBudgetContent(
         for summary: BudgetSummary,
-        proxy: RootTabPageProxy,
-        availableContentHeight: CGFloat
+        proxy: RootTabPageProxy
     ) -> some View {
-        let fallbackHeight = proxy.availableHeight - proxy.headerHeight
-        let resolvedHeight = max(availableContentHeight > 0 ? availableContentHeight : fallbackHeight, 1)
+        let resolvedHeight = max(proxy.availableHeightBelowHeader, 1)
 
         RootTabListHostingContainer(height: resolvedHeight) {
             BudgetDetailsView(
@@ -378,10 +358,6 @@ struct HomeView: View {
             .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
         }
     }
-
-
-    private var headerSectionSpacing: CGFloat { DS.Spacing.xs / 2 }
-
     // MARK: Helpers
     private func title(for date: Date) -> String {
         budgetPeriod.title(for: date)
@@ -401,11 +377,6 @@ struct HomeView: View {
     }
 
     private var headerContentSpacing: CGFloat { DS.Spacing.s }
-
-    private func resolvedAvailableContentHeight(using proxy: RootTabPageProxy) -> CGFloat {
-        let spacingContribution = headerContentHeight > 0 ? headerContentSpacing : 0
-        return max(proxy.availableHeight - headerContentHeight - spacingContribution, 0)
-    }
 
     private var primarySummary: BudgetSummary? {
         if case .loaded(let summaries) = vm.state {
@@ -747,14 +718,6 @@ private enum HomeHeaderOverviewMetrics {
     static let valueFont: Font = .body.weight(.semibold)
     static let totalValueFont: Font = .title3.weight(.semibold)
     static let fallbackCurrencyCode = "USD"
-}
-
-private struct HomeHeaderHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(0, nextValue())
-    }
 }
 
 // MARK: - Segmented control sizing helpers


### PR DESCRIPTION
## Summary
- feed HomeView header through RootTabPageScaffold so the scaffold measures and spaces it correctly
- drop local geometry measurement logic and use RootTabPageProxy.availableHeightBelowHeader for content sizing
- ensure empty and loaded states respect the scaffold padding and available height helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db3db47908832cb742391320b2037b