### PR TITLE
fix: prevent HomeView scaffold from wrapping budget lists

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -48,7 +48,8 @@ struct HomeView: View {
         //   control of vertical scrolling without nested scroll views.
         RootTabPageScaffold(
             scrollBehavior: .auto,
-            spacing: headerContentSpacing
+            spacing: headerContentSpacing,
+            wrapsContentInScrollView: false
         ) {
             headerSection
         } content: { proxy in


### PR DESCRIPTION
## Summary
- disable RootTabPageScaffold's automatic content scroll wrapping in HomeView to avoid nested scroll views
- keep budget lists as the sole scroll hosts when navigating between periods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db36f32d34832c9bf40865300e62af