### PR TITLE
fix: ensure HomeView scroll host when empty

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -48,8 +48,9 @@ struct HomeView: View {
         // - Loaded budgets embed the overview header within BudgetDetailsView so
         //   the summary and expense lists share a single scroll container.
         RootTabPageScaffold(
-            scrollBehavior: .auto,
-            spacing: 0
+            scrollBehavior: requiresScaffoldScrollHosting ? .always : .auto,
+            spacing: 0,
+            wrapsContentInScrollView: requiresScaffoldScrollHosting
         ) { _ in
             EmptyView()
         } content: { proxy in
@@ -401,6 +402,10 @@ struct HomeView: View {
             return summaries.first
         }
         return nil
+    }
+
+    private var requiresScaffoldScrollHosting: Bool {
+        primarySummary == nil
     }
 
     private var emptyShellMessage: String {


### PR DESCRIPTION
## Summary
- derive HomeView's RootTabPageScaffold scroll behaviour from the current load state
- keep the scaffold's scroll view disabled when a budget is loaded to avoid nested scroll views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db5c958e0c832c905e4eb544db7c24