### PR TITLE
fix: align home header padding in budget list

### DIFF
--- a/OffshoreBudgeting/Views/Components/RootTabHeader.swift
+++ b/OffshoreBudgeting/Views/Components/RootTabHeader.swift
@@ -6,6 +6,7 @@ enum RootTabHeaderLayout {
     enum TopPaddingStyle {
         case standard
         case navigationBarAligned
+        case contentEmbedded
     }
     enum TrailingPlacement {
         /// Default: title expands to fill and trailing controls are pinned right.
@@ -91,6 +92,8 @@ struct RootTabHeader<Trailing: View>: View {
             return standardTopPadding
         case .navigationBarAligned:
             return navigationBarAlignedTopPadding
+        case .contentEmbedded:
+            return contentEmbeddedTopPadding
         }
     }
 
@@ -110,6 +113,10 @@ struct RootTabHeader<Trailing: View>: View {
         // Keep parity with standard for now; can be tweaked to align with a nav bar if needed.
         return effectiveSafeAreaInsets.top + DS.Spacing.l
         #endif
+    }
+
+    private var contentEmbeddedTopPadding: CGFloat {
+        DS.Spacing.l
     }
 
     private var effectiveSafeAreaInsets: EdgeInsets {

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -126,12 +126,16 @@ struct HomeView: View {
     }
 
     @ViewBuilder
-    private func homeOverviewHeader(for summary: BudgetSummary?) -> some View {
+    private func homeOverviewHeader(
+        for summary: BudgetSummary?,
+        topPaddingStyle: RootTabHeaderLayout.TopPaddingStyle = .standard
+    ) -> some View {
         VStack(spacing: HomeHeaderOverviewMetrics.sectionSpacing) {
             RootViewTopPlanes(
                 title: "Home",
                 titleDisplayMode: .hidden,
-                horizontalPadding: RootTabHeaderLayout.defaultHorizontalPadding
+                horizontalPadding: RootTabHeaderLayout.defaultHorizontalPadding,
+                topPaddingStyle: topPaddingStyle
             )
 
             HomeHeaderOverviewTable(
@@ -365,7 +369,10 @@ struct HomeView: View {
             },
             headerManagesPadding: true,
             header: {
-                homeOverviewHeader(for: summary)
+                homeOverviewHeader(
+                    for: summary,
+                    topPaddingStyle: .contentEmbedded
+                )
             }
         )
         .id(summary.id)


### PR DESCRIPTION
## Summary
- allow root tab headers to use a content-embedded padding style that omits the safe-area offset
- trim the home overview header padding when embedded in the budget details list to match empty state spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbca483b3c832ca1361a5fa7b25186