### PR TITLE
Align budget header typography scaling

### DIFF
--- a/OffshoreBudgeting/Views/BudgetDetailsView.swift
+++ b/OffshoreBudgeting/Views/BudgetDetailsView.swift
@@ -384,6 +384,10 @@ struct BudgetDetailsView: View {
 
 // MARK: - Scrolling List Header Content
 private extension BudgetDetailsView {
+    private enum BudgetDetailsHeaderMetrics {
+        static let titleSpacing: CGFloat = 4
+    }
+
     @ViewBuilder
     var listHeader: some View {
         VStack(alignment: .leading, spacing: headerSpacing) {
@@ -391,17 +395,14 @@ private extension BudgetDetailsView {
             if displaysBudgetTitle || shouldShowPeriodNavigation {
                 HStack(alignment: .top, spacing: DS.Spacing.m) {
                     if displaysBudgetTitle {
-                        VStack(alignment: .leading, spacing: 4) {
+                        BudgetHeaderTitleBlock(spacing: BudgetDetailsHeaderMetrics.titleSpacing) {
                             Text(vm.budget?.name ?? "Budget")
                                 .font(.largeTitle.bold())
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.75)
-
+                        } detail: {
                             if let startDate = vm.budget?.startDate,
                                let endDate = vm.budget?.endDate {
                                 Text("\(Self.mediumDate(startDate)) through \(Self.mediumDate(endDate))")
                                     .foregroundStyle(.secondary)
-                                    .lineLimit(1)
                             }
                         }
                     }

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -514,19 +514,18 @@ private struct HomeHeaderOverviewTable: View {
     }
 
     private var titleStack: some View {
-        VStack(alignment: .leading, spacing: HomeHeaderOverviewMetrics.titleSpacing) {
+        BudgetHeaderTitleBlock(
+            spacing: HomeHeaderOverviewMetrics.titleSpacing,
+            titleMinimumScaleFactor: HomeHeaderOverviewMetrics.titleMinimumScaleFactor,
+            detailMinimumScaleFactor: HomeHeaderOverviewMetrics.subtitleMinimumScaleFactor
+        ) {
             Text(displayTitle)
                 .font(HomeHeaderOverviewMetrics.titleFont)
-                .lineLimit(HomeHeaderOverviewMetrics.titleLineLimit)
-                .minimumScaleFactor(HomeHeaderOverviewMetrics.titleMinimumScaleFactor)
-
+        } detail: {
             Text(displayDetail)
                 .font(HomeHeaderOverviewMetrics.subtitleFont)
                 .foregroundStyle(.secondary)
-                .lineLimit(HomeHeaderOverviewMetrics.subtitleLineLimit)
-                .minimumScaleFactor(HomeHeaderOverviewMetrics.subtitleMinimumScaleFactor)
         }
-        .accessibilityElement(children: .combine)
     }
 
     private var periodNavigationControlView: some View {
@@ -731,15 +730,60 @@ private enum HomeHeaderOverviewMetrics {
     static let legacyTitleToPeriodNavigationSpacing: CGFloat = DS.Spacing.xs
     static let categoryChipTopSpacing: CGFloat = DS.Spacing.s
     static let titleFont: Font = .largeTitle.bold()
-    static let titleLineLimit: Int = 1
-    static let titleMinimumScaleFactor: CGFloat = 0.65
+    static let titleMinimumScaleFactor: CGFloat = BudgetHeaderTitleLayout.titleMinimumScaleFactor
     static let subtitleFont: Font = .callout
-    static let subtitleLineLimit: Int = 1
-    static let subtitleMinimumScaleFactor: CGFloat = 0.85
+    static let subtitleMinimumScaleFactor: CGFloat = BudgetHeaderTitleLayout.detailMinimumScaleFactor
     static let labelFont: Font = .caption.weight(.semibold)
     static let valueFont: Font = .body.weight(.semibold)
     static let totalValueFont: Font = .title3.weight(.semibold)
     static let fallbackCurrencyCode = "USD"
+}
+
+// MARK: - Shared Header Title Block
+
+struct BudgetHeaderTitleBlock<Title: View, Detail: View>: View {
+    private let spacing: CGFloat
+    private let titleMinimumScaleFactor: CGFloat
+    private let detailMinimumScaleFactor: CGFloat
+    private let title: () -> Title
+    private let detail: () -> Detail
+
+    init(
+        spacing: CGFloat,
+        titleMinimumScaleFactor: CGFloat = BudgetHeaderTitleLayout.titleMinimumScaleFactor,
+        detailMinimumScaleFactor: CGFloat = BudgetHeaderTitleLayout.detailMinimumScaleFactor,
+        @ViewBuilder title: @escaping () -> Title,
+        @ViewBuilder detail: @escaping () -> Detail
+    ) {
+        self.spacing = spacing
+        self.titleMinimumScaleFactor = titleMinimumScaleFactor
+        self.detailMinimumScaleFactor = detailMinimumScaleFactor
+        self.title = title
+        self.detail = detail
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            title()
+                .lineLimit(BudgetHeaderTitleLayout.titleLineLimit)
+                .layoutPriority(2)
+                .fixedSize(horizontal: true, vertical: false)
+                .minimumScaleFactor(titleMinimumScaleFactor)
+
+            detail()
+                .lineLimit(BudgetHeaderTitleLayout.detailLineLimit)
+                .layoutPriority(0)
+                .minimumScaleFactor(detailMinimumScaleFactor)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+enum BudgetHeaderTitleLayout {
+    static let titleLineLimit: Int = 1
+    static let detailLineLimit: Int = 1
+    static let titleMinimumScaleFactor: CGFloat = 0.75
+    static let detailMinimumScaleFactor: CGFloat = 0.75
 }
 
 // MARK: - Segmented control sizing helpers


### PR DESCRIPTION
## Summary
- apply consistent layout priorities and minimum scale factors to the home header title/detail to preserve typography
- share a BudgetHeaderTitleBlock helper with BudgetDetailsView so empty and populated states scale identically
- note: previous list row width forced the title to shrink on iOS/macOS; the updated modifiers keep the larger style across platforms

## Testing
- not run (UI change only)

## Screenshots
- Unable to capture before/after headers in this environment; please validate on device/simulator.


------
https://chatgpt.com/codex/tasks/task_e_68dbd7ca59d0832ca6edd97f7a0c30d8