### PR TITLE
feat: allow customizing category chip inset

### DIFF
--- a/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
+++ b/OffshoreBudgeting/Views/Components/CategoryTotalsRow.swift
@@ -4,7 +4,6 @@
 //
 //  Shared horizontal chip row displaying spending per category.
 //
-
 import SwiftUI
 
 // MARK: - CategoryTotalsRow
@@ -12,6 +11,7 @@ import SwiftUI
 struct CategoryTotalsRow: View {
     let categories: [BudgetSummary.CategorySpending]
     var isPlaceholder: Bool = false
+    var horizontalInset: CGFloat = DS.Spacing.l
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -33,7 +33,7 @@ struct CategoryTotalsRow: View {
                     )
                 }
             }
-            .padding(.horizontal, DS.Spacing.l)
+            .padding(.horizontal, horizontalInset)
         }
         .ub_hideScrollIndicators()
         .frame(minHeight: chipRowMinHeight)

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -569,7 +569,8 @@ private struct HomeHeaderOverviewTable: View {
     private var categoryRow: some View {
         CategoryTotalsRow(
             categories: categorySpending,
-            isPlaceholder: categorySpending.isEmpty
+            isPlaceholder: categorySpending.isEmpty,
+            horizontalInset: 0
         )
         .padding(.top, HomeHeaderOverviewMetrics.categoryChipTopSpacing)
     }


### PR DESCRIPTION
## Summary
- add a configurable horizontal inset to CategoryTotalsRow with a default matching the design system spacing
- update HomeView to pass zero inset for the header row to avoid stacked padding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfdbb89e8832ca3f46f9f591432e0