### PR TITLE
fix(view): preserve home scrolling

### DIFF
--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -299,7 +299,7 @@ struct HomeView: View {
 
             case .loaded(let summaries):
                 if let first = summaries.first {
-                    loadedBudgetContent(for: first)
+                    loadedBudgetContent(for: first, proxy: proxy)
                 } else {
                     emptyPeriodContent(proxy: proxy)
                 }
@@ -347,9 +347,15 @@ struct HomeView: View {
 
     @ViewBuilder
     private func loadedBudgetContent(
-        for summary: BudgetSummary
+        for summary: BudgetSummary,
+        proxy: RootTabPageProxy
     ) -> some View {
         homeHeaderPage(for: summary, topPaddingStyle: .contentEmbedded) { header in
+            let bottomInset = proxy.tabContentBottomPadding(
+                includeSafeArea: false,
+                tabBarGutter: proxy.compactAwareTabBarGutter
+            )
+
             BudgetDetailsView(
                 budgetObjectID: summary.id,
                 periodNavigation: nil,
@@ -368,6 +374,11 @@ struct HomeView: View {
             )
             .id(summary.id)
             .environment(\.managedObjectContext, CoreDataService.shared.viewContext)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                Color.clear
+                    .frame(height: bottomInset)
+                    .allowsHitTesting(false)
+            }
         }
     }
     // MARK: Helpers


### PR DESCRIPTION
## Summary
- forward the root tab proxy to the loaded budget content path so it can reason about available insets
- add a proxy-driven bottom safe area inset beneath BudgetDetailsView to allow scrolling beyond the tab bar

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dc10affd3c832c8e525f91e5aa74d7