### PR TITLE
fix: ensure data wipes notify all observers

### DIFF
--- a/OffshoreBudgeting/View Models/CardsViewModel.swift
+++ b/OffshoreBudgeting/View Models/CardsViewModel.swift
@@ -81,6 +81,14 @@ final class CardsViewModel: ObservableObject {
                 self?.reapplyThemes()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .dataStoreDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { await self.refresh() }
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: startIfNeeded()

--- a/OffshoreBudgeting/Views/HomeView.swift
+++ b/OffshoreBudgeting/Views/HomeView.swift
@@ -89,6 +89,12 @@ struct HomeView: View {
             let newPeriod = BudgetPeriod(rawValue: newValue) ?? .monthly
             vm.updateBudgetPeriod(to: newPeriod)
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .dataStoreDidChange)
+                .receive(on: RunLoop.main)
+        ) { _ in
+            Task { await vm.refresh() }
+        }
 
         // MARK: ADD SHEET — present new budget UI for the selected period
         .sheet(isPresented: $isPresentingAddBudget, content: makeAddBudgetView)


### PR DESCRIPTION
## Summary
- merge batch-delete object IDs back into all registered contexts and reset them after wiping Core Data
- track background contexts created by the service so deletes clear any registered objects
- listen for data-store change notifications in Home and Cards flows to refresh immediately after a wipe

## Testing
- not run (not available on linux)

------
https://chatgpt.com/codex/tasks/task_e_68dd28f412ec832c8cc0e52675ba2958